### PR TITLE
Release 5.2.0.19192

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -417,6 +417,25 @@
                 "sha1": "9215ea0c77abc6ebf8f89a9157729fe2103f6eba",
                 "sha256": "62154a9c6fb582452e58c5c9803e416bc6b89a6e4f19d259e25fb0d86aa4290b"
             }
+        },
+        {
+            "id": "19192",
+            "name": "5.2.0.19192",
+            "date": "2016-12-07 14:37:31",
+            "track": "stable",
+            "commit": "127b49580902853e7152278ef173eb8737e4bd93",
+            "detail_url": "https://deskpro.github.io/releases/stable/2016-12/19192/release.json",
+            "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2016-12/19192/",
+            "filesize": 190531564,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "1b91a02",
+                "md5": "896d7519d79a4313b87a9ff91386862c",
+                "sha1": "e5794bbd48980937f5d8c5a0aa027f428d74930a",
+                "sha256": "66074fbea891c8d0504647ed4f1bcc73ebcfbac3f8e98f52df1e0023564d16d3"
+            }
         }
     ]
 }

--- a/releases/stable/2016-12/19192/deskpro.zip
+++ b/releases/stable/2016-12/19192/deskpro.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66074fbea891c8d0504647ed4f1bcc73ebcfbac3f8e98f52df1e0023564d16d3
+size 190531564

--- a/releases/stable/2016-12/19192/release.json
+++ b/releases/stable/2016-12/19192/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "19192",
+    "name": "5.2.0.19192",
+    "date": "2016-12-07 14:37:31",
+    "track": "stable",
+    "commit": "127b49580902853e7152278ef173eb8737e4bd93",
+    "detail_url": "https://deskpro.github.io/releases/stable/2016-12/19192/release.json",
+    "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2016-12/19192/",
+    "filesize": 190531564,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "1b91a02",
+        "md5": "896d7519d79a4313b87a9ff91386862c",
+        "sha1": "e5794bbd48980937f5d8c5a0aa027f428d74930a",
+        "sha256": "66074fbea891c8d0504647ed4f1bcc73ebcfbac3f8e98f52df1e0023564d16d3"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.2.0.19192.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#19192](http://builder.deskprodemo.com/build/19192/)
