### PR TITLE
Release 5.2.5.19794

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -512,6 +512,25 @@
                 "sha1": "27f9adfa1818bb27ae21c40b6b67da98c28d5d14",
                 "sha256": "791ccbf6961c6fadadeb1c6eedd3481599b133ec4caac12f2e240cf8368adb0f"
             }
+        },
+        {
+            "id": "19794",
+            "name": "5.2.5.19794",
+            "date": "2016-12-19 14:30:33",
+            "track": "stable",
+            "commit": "a8abfa8eb9dd76df74a017917099814f16825110",
+            "detail_url": "https://deskpro.github.io/releases/stable/2016-12/19794/release.json",
+            "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2016-12/19794/deskpro.zip",
+            "filesize": 195733750,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "223ebf37",
+                "md5": "8450255bf2651f1fcb037c756c27e53a",
+                "sha1": "5a391b1913bc6253209622cf7b4c33b255ad5cf7",
+                "sha256": "f52db3a19fcce91ef66caa3d81f9eb89024bbfa0243ceabd252fe9f8c380bbc4"
+            }
         }
     ]
 }

--- a/releases/stable/2016-12/19794/deskpro.zip
+++ b/releases/stable/2016-12/19794/deskpro.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f52db3a19fcce91ef66caa3d81f9eb89024bbfa0243ceabd252fe9f8c380bbc4
+size 195733750

--- a/releases/stable/2016-12/19794/release.json
+++ b/releases/stable/2016-12/19794/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "19794",
+    "name": "5.2.5.19794",
+    "date": "2016-12-19 14:30:33",
+    "track": "stable",
+    "commit": "a8abfa8eb9dd76df74a017917099814f16825110",
+    "detail_url": "https://deskpro.github.io/releases/stable/2016-12/19794/release.json",
+    "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2016-12/19794/deskpro.zip",
+    "filesize": 195733750,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "223ebf37",
+        "md5": "8450255bf2651f1fcb037c756c27e53a",
+        "sha1": "5a391b1913bc6253209622cf7b4c33b255ad5cf7",
+        "sha256": "f52db3a19fcce91ef66caa3d81f9eb89024bbfa0243ceabd252fe9f8c380bbc4"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.2.5.19794.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#19794](http://builder.deskprodemo.com/build/19794/)
