### PR TITLE
Release 5.5.3.24224

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -721,6 +721,25 @@
                 "sha1": "5a1f24b73cff7fd2420e12abc279080145ac4a5c",
                 "sha256": "bfefd2505a3e876a7728dc8a556870fa0ab92b7947f2e318941cf992aa01ff62"
             }
+        },
+        {
+            "id": "24224",
+            "name": "5.5.3.24224",
+            "date": "2017-04-07 08:40:38",
+            "track": "stable",
+            "commit": "5f0c72ac93f15b37db14bcb9095078e083384aab",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-04/24224/release.json",
+            "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2017-04/24224/deskpro.zip",
+            "filesize": 211258439,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "1c14d526",
+                "md5": "f08a2e123795e7f974397badb8c54b61",
+                "sha1": "111483fbcf0aeeb22e082d92604e0eb604302139",
+                "sha256": "4d03829cb2fe632a353fdf3538b9581ca6e68911e4d214f160598deb99b0c9f6"
+            }
         }
     ]
 }

--- a/releases/stable/2017-04/24224/deskpro.zip
+++ b/releases/stable/2017-04/24224/deskpro.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d03829cb2fe632a353fdf3538b9581ca6e68911e4d214f160598deb99b0c9f6
+size 211258439

--- a/releases/stable/2017-04/24224/release.json
+++ b/releases/stable/2017-04/24224/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "24224",
+    "name": "5.5.3.24224",
+    "date": "2017-04-07 08:40:38",
+    "track": "stable",
+    "commit": "5f0c72ac93f15b37db14bcb9095078e083384aab",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-04/24224/release.json",
+    "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2017-04/24224/deskpro.zip",
+    "filesize": 211258439,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "1c14d526",
+        "md5": "f08a2e123795e7f974397badb8c54b61",
+        "sha1": "111483fbcf0aeeb22e082d92604e0eb604302139",
+        "sha256": "4d03829cb2fe632a353fdf3538b9581ca6e68911e4d214f160598deb99b0c9f6"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.5.3.24224.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#24224](http://builder.deskprodemo.com/build/24224/)
