### PR TITLE
Release 5.5.4.24279

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -740,6 +740,25 @@
                 "sha1": "111483fbcf0aeeb22e082d92604e0eb604302139",
                 "sha256": "4d03829cb2fe632a353fdf3538b9581ca6e68911e4d214f160598deb99b0c9f6"
             }
+        },
+        {
+            "id": "24279",
+            "name": "5.5.4.24279",
+            "date": "2017-04-11 08:58:43",
+            "track": "stable",
+            "commit": "d9cfccf4a98b7a3533ea87da6f87cd2d14458e21",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-04/24279/release.json",
+            "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2017-04/24279/deskpro.zip",
+            "filesize": 210765890,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "37582ca3",
+                "md5": "7523956b49bd23059dad450e1595187e",
+                "sha1": "8540604b810b1704e91f5148c98d0069f34fce1e",
+                "sha256": "8a6b2997326409ac20dee5ad23e8b8d6f48a0159d18fee52401fde6bb2472415"
+            }
         }
     ]
 }

--- a/releases/stable/2017-04/24279/deskpro.zip
+++ b/releases/stable/2017-04/24279/deskpro.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a6b2997326409ac20dee5ad23e8b8d6f48a0159d18fee52401fde6bb2472415
+size 210765890

--- a/releases/stable/2017-04/24279/release.json
+++ b/releases/stable/2017-04/24279/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "24279",
+    "name": "5.5.4.24279",
+    "date": "2017-04-11 08:58:43",
+    "track": "stable",
+    "commit": "d9cfccf4a98b7a3533ea87da6f87cd2d14458e21",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-04/24279/release.json",
+    "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2017-04/24279/deskpro.zip",
+    "filesize": 210765890,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "37582ca3",
+        "md5": "7523956b49bd23059dad450e1595187e",
+        "sha1": "8540604b810b1704e91f5148c98d0069f34fce1e",
+        "sha256": "8a6b2997326409ac20dee5ad23e8b8d6f48a0159d18fee52401fde6bb2472415"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.5.4.24279.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#24279](http://builder.deskprodemo.com/build/24279/)
