### PR TITLE
Release 5.5.6.25178

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -816,6 +816,25 @@
                 "sha1": "7ad1290be1a6bb5778755d058e0b617eea94a470",
                 "sha256": "57cfbf0813755dd9fbea57f8e384e5d3d181f68aba4c716c7cb53461685a8b9e"
             }
+        },
+        {
+            "id": "25178",
+            "name": "5.5.6.25178",
+            "date": "2017-05-02 15:22:30",
+            "track": "stable",
+            "commit": "eb2ff906c7302eda3e700c927cfa2193e4e355c4",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-05/25178/release.json",
+            "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2017-05/25178/deskpro.zip",
+            "filesize": 212097360,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "60e48bde",
+                "md5": "b07b897ac36b526764fc4bb2043dc1a3",
+                "sha1": "7703ff811c2c51b3b51924da08ccca543526847c",
+                "sha256": "1ab5fe78188a4e28793344ab4bbff481617fe6001eea11b53893a15ca80258f1"
+            }
         }
     ]
 }

--- a/releases/stable/2017-05/25178/deskpro.zip
+++ b/releases/stable/2017-05/25178/deskpro.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ab5fe78188a4e28793344ab4bbff481617fe6001eea11b53893a15ca80258f1
+size 212097360

--- a/releases/stable/2017-05/25178/release.json
+++ b/releases/stable/2017-05/25178/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "25178",
+    "name": "5.5.6.25178",
+    "date": "2017-05-02 15:22:30",
+    "track": "stable",
+    "commit": "eb2ff906c7302eda3e700c927cfa2193e4e355c4",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-05/25178/release.json",
+    "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2017-05/25178/deskpro.zip",
+    "filesize": 212097360,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "60e48bde",
+        "md5": "b07b897ac36b526764fc4bb2043dc1a3",
+        "sha1": "7703ff811c2c51b3b51924da08ccca543526847c",
+        "sha256": "1ab5fe78188a4e28793344ab4bbff481617fe6001eea11b53893a15ca80258f1"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.5.6.25178.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#25178](http://builder.deskprodemo.com/build/25178/)
