### PR TITLE
Release 5.5.6.25206

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -797,6 +797,25 @@
                 "sha1": "7506f203880ecfc78e2175a1734692b64608c304",
                 "sha256": "90cf87abc04241b07c318ae2f929a8aac2d451decf054437d11869e5fa52cb3d"
             }
+        },
+        {
+            "id": "25206",
+            "name": "5.5.6.25206",
+            "date": "2017-05-03 14:40:35",
+            "track": "stable",
+            "commit": "2ef9c3fd89d45d8af59239aabe69fc58f8e627bb",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-05/25206/release.json",
+            "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2017-05/25206/deskpro.zip",
+            "filesize": 212096716,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "53f6af5",
+                "md5": "cb685491ad0cb49be1580258aacc7f56",
+                "sha1": "31a7f2248bda74e0e67787f16f86ebffcb6b9c04",
+                "sha256": "417bd813036db014140fd889b3ce41c8d3f96c4fade3495907df8369c1def645"
+            }
         }
     ]
 }

--- a/releases/stable/2017-05/25206/deskpro.zip
+++ b/releases/stable/2017-05/25206/deskpro.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:417bd813036db014140fd889b3ce41c8d3f96c4fade3495907df8369c1def645
+size 212096716

--- a/releases/stable/2017-05/25206/release.json
+++ b/releases/stable/2017-05/25206/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "25206",
+    "name": "5.5.6.25206",
+    "date": "2017-05-03 14:40:35",
+    "track": "stable",
+    "commit": "2ef9c3fd89d45d8af59239aabe69fc58f8e627bb",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-05/25206/release.json",
+    "zip_url": "https://media.githubusercontent.com/media/DeskPRO/deskpro.github.io/master/releases/stable/2017-05/25206/deskpro.zip",
+    "filesize": 212096716,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "53f6af5",
+        "md5": "cb685491ad0cb49be1580258aacc7f56",
+        "sha1": "31a7f2248bda74e0e67787f16f86ebffcb6b9c04",
+        "sha256": "417bd813036db014140fd889b3ce41c8d3f96c4fade3495907df8369c1def645"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.5.6.25206.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#25206](http://builder.deskprodemo.com/build/25206/)
