### PR TITLE
Release 5.6.3.27826

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -911,6 +911,25 @@
                 "sha1": "df3e006df4a8476df2e6993492a3bccfefb3b19c",
                 "sha256": "b379c9acf7b396350a968900b1b481decf19124fdb18ffd489233b43206b8073"
             }
+        },
+        {
+            "id": "27826",
+            "name": "5.6.3.27826",
+            "date": "2017-06-16 17:09:59",
+            "track": "stable",
+            "commit": "52f6228d177f4ce84728b521b47994dbb07bbe8a",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-06/27826/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.6.3.27826/deskpro.zip",
+            "filesize": 215201858,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "22d8d52",
+                "md5": "0a89630258c3268a4dae955df2c09c22",
+                "sha1": "afd675c4fd2451205b112540ac5cb4de3dd5786e",
+                "sha256": "33c68e393782e072e342532fa9f2b175c289209c687d4e6fae8a2930164c3203"
+            }
         }
     ]
 }

--- a/releases/stable/2017-06/27826/release.json
+++ b/releases/stable/2017-06/27826/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "27826",
+    "name": "5.6.3.27826",
+    "date": "2017-06-16 17:09:59",
+    "track": "stable",
+    "commit": "52f6228d177f4ce84728b521b47994dbb07bbe8a",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-06/27826/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.6.3.27826/deskpro.zip",
+    "filesize": 215201858,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "22d8d52",
+        "md5": "0a89630258c3268a4dae955df2c09c22",
+        "sha1": "afd675c4fd2451205b112540ac5cb4de3dd5786e",
+        "sha256": "33c68e393782e072e342532fa9f2b175c289209c687d4e6fae8a2930164c3203"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.6.3.27826.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#27826](http://builder.deskprodemo.com/build/27826/)
