### PR TITLE
Release 5.7.1.28466

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -987,6 +987,25 @@
                 "sha1": "d1b759ab6088778b270d957d53adcf6670341bed",
                 "sha256": "505c3f4618b1a11af6e316b19a6f353aa2a40ba6af63032772256ecac04b3edd"
             }
+        },
+        {
+            "id": "28466",
+            "name": "5.7.1.28466",
+            "date": "2017-07-07 11:21:33",
+            "track": "stable",
+            "commit": "b5579ca5041d9b8e1a4158020428798c713a2482",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-07/28466/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.7.1.28466/deskpro.zip",
+            "filesize": 213750120,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "17cd94f7",
+                "md5": "009a612c60c42fdbc14248f625fa367f",
+                "sha1": "3fe62a706aaa441812462577a9ddb8bf9c2eaa2c",
+                "sha256": "23bd834453c12eefb2bac13fc8ad1bd5a2891e3ac31ab1d300fcde40f4802d4c"
+            }
         }
     ]
 }

--- a/releases/stable/2017-07/28466/release.json
+++ b/releases/stable/2017-07/28466/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "28466",
+    "name": "5.7.1.28466",
+    "date": "2017-07-07 11:21:33",
+    "track": "stable",
+    "commit": "b5579ca5041d9b8e1a4158020428798c713a2482",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-07/28466/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.7.1.28466/deskpro.zip",
+    "filesize": 213750120,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "17cd94f7",
+        "md5": "009a612c60c42fdbc14248f625fa367f",
+        "sha1": "3fe62a706aaa441812462577a9ddb8bf9c2eaa2c",
+        "sha256": "23bd834453c12eefb2bac13fc8ad1bd5a2891e3ac31ab1d300fcde40f4802d4c"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.7.1.28466.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#28466](http://builder.deskprodemo.com/build/28466/)
