### PR TITLE
Release 5.9.0.30456

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1101,6 +1101,25 @@
                 "sha1": "9bfd73fac082b5f0d6ceb7eb9d0a9e308d7317b6",
                 "sha256": "7a596d11ca72bccf9e38cb0b9b39cd87717a6bce2843e24986b3ead808af0c3f"
             }
+        },
+        {
+            "id": "30456",
+            "name": "5.9.0.30456",
+            "date": "2017-08-23 14:33:36",
+            "track": "stable",
+            "commit": "9fe9caac940f995e5547ef0e90b010f4f6269d3d",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-08/30456/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.9.0.30456/deskpro.zip",
+            "filesize": 217092002,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "26d38868",
+                "md5": "2be85dfc5d524c20584b962365801488",
+                "sha1": "d9d18011ba926c5ffcff47bb3794749f825fd986",
+                "sha256": "87b011e322c4707db9ee3b49f3125258b557f6b1dfaa894151a0245a4b08c8fb"
+            }
         }
     ]
 }

--- a/releases/stable/2017-08/30456/release.json
+++ b/releases/stable/2017-08/30456/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "30456",
+    "name": "5.9.0.30456",
+    "date": "2017-08-23 14:33:36",
+    "track": "stable",
+    "commit": "9fe9caac940f995e5547ef0e90b010f4f6269d3d",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-08/30456/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.9.0.30456/deskpro.zip",
+    "filesize": 217092002,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "26d38868",
+        "md5": "2be85dfc5d524c20584b962365801488",
+        "sha1": "d9d18011ba926c5ffcff47bb3794749f825fd986",
+        "sha256": "87b011e322c4707db9ee3b49f3125258b557f6b1dfaa894151a0245a4b08c8fb"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.9.0.30456.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#30456](http://builder.deskprodemo.com/build/30456/)
