### PR TITLE
Release 5.10.30898

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1139,6 +1139,25 @@
                 "sha1": "83de19fef6a2176805cea5d44576a72929d8f536",
                 "sha256": "a56345beab6c9441b15cecde1d6cd46e0dd143d08a48a9a2fe94b0f96507136f"
             }
+        },
+        {
+            "id": "30898",
+            "name": "5.10.30898",
+            "date": "2017-09-11 09:32:33",
+            "track": "stable",
+            "commit": "0736a0a076e4fde2c6f5233a5b4dc77daa019ff2",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-09/30898/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.10.30898/deskpro.zip",
+            "filesize": 217198112,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "69ee8873",
+                "md5": "70b085fb05f0ba64e425764da0e043f0",
+                "sha1": "ff07ec4749484917653171685c3ca3f57d4b34b8",
+                "sha256": "c415baef038a64f3415ddaa28abed8d5dc232eb52c7a34933dc7502c06b8dd91"
+            }
         }
     ]
 }

--- a/releases/stable/2017-09/30898/release.json
+++ b/releases/stable/2017-09/30898/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "30898",
+    "name": "5.10.30898",
+    "date": "2017-09-11 09:32:33",
+    "track": "stable",
+    "commit": "0736a0a076e4fde2c6f5233a5b4dc77daa019ff2",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-09/30898/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.10.30898/deskpro.zip",
+    "filesize": 217198112,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "69ee8873",
+        "md5": "70b085fb05f0ba64e425764da0e043f0",
+        "sha1": "ff07ec4749484917653171685c3ca3f57d4b34b8",
+        "sha256": "c415baef038a64f3415ddaa28abed8d5dc232eb52c7a34933dc7502c06b8dd91"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.10.30898.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#30898](http://builder.deskprodemo.com/build/30898/)
