### PR TITLE
Release 5.10.4.31120

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1234,6 +1234,25 @@
                 "sha1": "b0ba7aea821c5a3c5119985e1e9f01ad51c9145f",
                 "sha256": "54af284ee271422ada1c00fd197acf5f561f0daef326debba9d70f8ed71cb973"
             }
+        },
+        {
+            "id": "31120",
+            "name": "5.10.4.31120",
+            "date": "2017-10-09 09:57:33",
+            "track": "stable",
+            "commit": "60375d7ef95b3a8c0965a1b39e55e26014df1e80",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-10/31120/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.10.4.31120/deskpro.zip",
+            "filesize": 215580828,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "7fb1eaf7",
+                "md5": "f63572ec5d8961cda5d058db6b546a33",
+                "sha1": "148af7e8cc1131323724e8d4181c15a693b0e05b",
+                "sha256": "4b44cc352e80703ae42f8ee30347497266af3bc843d6d90e377726bc02602e84"
+            }
         }
     ]
 }

--- a/releases/stable/2017-10/31120/release.json
+++ b/releases/stable/2017-10/31120/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "31120",
+    "name": "5.10.4.31120",
+    "date": "2017-10-09 09:57:33",
+    "track": "stable",
+    "commit": "60375d7ef95b3a8c0965a1b39e55e26014df1e80",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-10/31120/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.10.4.31120/deskpro.zip",
+    "filesize": 215580828,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "7fb1eaf7",
+        "md5": "f63572ec5d8961cda5d058db6b546a33",
+        "sha1": "148af7e8cc1131323724e8d4181c15a693b0e05b",
+        "sha256": "4b44cc352e80703ae42f8ee30347497266af3bc843d6d90e377726bc02602e84"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.10.4.31120.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#31120](http://builder.deskprodemo.com/build/31120/)
