### PR TITLE
Release 5.12.31462

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1310,6 +1310,25 @@
                 "sha1": "098ff39c877ff7b00066a72be428ce3139ff1516",
                 "sha256": "20ff6f833e05685f4ec63a5bc31c8e12a5f7c1312ddc8c217278cc1348c13250"
             }
+        },
+        {
+            "id": "31462",
+            "name": "5.12.31462",
+            "date": "2017-11-14 09:42:43",
+            "track": "stable",
+            "commit": "9ff6823a332617fc8bbd0f89c8d04cd31a815e76",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-11/31462/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.12.31462/deskpro.zip",
+            "filesize": 219045802,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "c0178191",
+                "md5": "01fa7c010756539e6eaaa4ad3b0a9c28",
+                "sha1": "eb3ec9edbbb60089d16724ef910c61da859ce3f9",
+                "sha256": "491ce5f73a5a0c3080086a7ab4baa70cb2af654a4ecd8d1a5bbecf6579ac9bc3"
+            }
         }
     ]
 }

--- a/releases/stable/2017-11/31462/release.json
+++ b/releases/stable/2017-11/31462/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "31462",
+    "name": "5.12.31462",
+    "date": "2017-11-14 09:42:43",
+    "track": "stable",
+    "commit": "9ff6823a332617fc8bbd0f89c8d04cd31a815e76",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-11/31462/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.12.31462/deskpro.zip",
+    "filesize": 219045802,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "c0178191",
+        "md5": "01fa7c010756539e6eaaa4ad3b0a9c28",
+        "sha1": "eb3ec9edbbb60089d16724ef910c61da859ce3f9",
+        "sha256": "491ce5f73a5a0c3080086a7ab4baa70cb2af654a4ecd8d1a5bbecf6579ac9bc3"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.12.31462.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#31462](http://builder.deskprodemo.com/build/31462/)
