### PR TITLE
Release 5.12.31464

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1310,6 +1310,25 @@
                 "sha1": "098ff39c877ff7b00066a72be428ce3139ff1516",
                 "sha256": "20ff6f833e05685f4ec63a5bc31c8e12a5f7c1312ddc8c217278cc1348c13250"
             }
+        },
+        {
+            "id": "31464",
+            "name": "5.12.31464",
+            "date": "2017-11-14 10:38:03",
+            "track": "stable",
+            "commit": "79b47803ac784aae4e5f8fcc5f8cfaaec171956e",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-11/31464/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.12.31464/deskpro.zip",
+            "filesize": 218489318,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "b86c0cca",
+                "md5": "6dddfb166b5831b601a2a911dda117a3",
+                "sha1": "0c767eeeb2d3c97d44c85e0d13bcfef03ce80070",
+                "sha256": "dd26c10cfa176f142fe41db0798d2b9915be5340790691decb64d3f545cb2f25"
+            }
         }
     ]
 }

--- a/releases/stable/2017-11/31464/release.json
+++ b/releases/stable/2017-11/31464/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "31464",
+    "name": "5.12.31464",
+    "date": "2017-11-14 10:38:03",
+    "track": "stable",
+    "commit": "79b47803ac784aae4e5f8fcc5f8cfaaec171956e",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-11/31464/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.12.31464/deskpro.zip",
+    "filesize": 218489318,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "b86c0cca",
+        "md5": "6dddfb166b5831b601a2a911dda117a3",
+        "sha1": "0c767eeeb2d3c97d44c85e0d13bcfef03ce80070",
+        "sha256": "dd26c10cfa176f142fe41db0798d2b9915be5340790691decb64d3f545cb2f25"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.12.31464.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#31464](http://builder.deskprodemo.com/build/31464/)
