### PR TITLE
Release 5.13.0.31627

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1386,6 +1386,25 @@
                 "sha1": "0c972a96ef590318a9f112066b7fbf8c0612baca",
                 "sha256": "658ac31d4567f51a7ffaddf1f28d90ab52bc15c3c575e4e3f83a637048685949"
             }
+        },
+        {
+            "id": "31627",
+            "name": "5.13.0.31627",
+            "date": "2017-11-27 14:25:59",
+            "track": "stable",
+            "commit": "a716f863a688e75a2938e70eb968aacd525ad1a3",
+            "detail_url": "https://deskpro.github.io/releases/stable/2017-11/31627/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.13.0.31627/deskpro.zip",
+            "filesize": 220611449,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "2abaeef1",
+                "md5": "e59e6387b7acadfc525a1d9f36f55171",
+                "sha1": "473f7ee220b511ccf486f1690d246290ab49c1cf",
+                "sha256": "1e5d5c1a29fed630f09a2e9fd1c2b18445d8df55893acee6e9956f2354914fb1"
+            }
         }
     ]
 }

--- a/releases/stable/2017-11/31627/release.json
+++ b/releases/stable/2017-11/31627/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "31627",
+    "name": "5.13.0.31627",
+    "date": "2017-11-27 14:25:59",
+    "track": "stable",
+    "commit": "a716f863a688e75a2938e70eb968aacd525ad1a3",
+    "detail_url": "https://deskpro.github.io/releases/stable/2017-11/31627/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.13.0.31627/deskpro.zip",
+    "filesize": 220611449,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "2abaeef1",
+        "md5": "e59e6387b7acadfc525a1d9f36f55171",
+        "sha1": "473f7ee220b511ccf486f1690d246290ab49c1cf",
+        "sha256": "1e5d5c1a29fed630f09a2e9fd1c2b18445d8df55893acee6e9956f2354914fb1"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.13.0.31627.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#31627](http://builder.deskprodemo.com/build/31627/)
