### PR TITLE
Release 5.14.2.31909

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1500,6 +1500,25 @@
                 "sha1": "8a57f433a7d353acb6ceb4e038b4f881e93b9079",
                 "sha256": "2bed174d25118dcbebe6d392aa8243408eac22adb4c12eab58b1fd8ccbf7d098"
             }
+        },
+        {
+            "id": "31909",
+            "name": "5.14.2.31909",
+            "date": "2018-01-03 10:46:40",
+            "track": "stable",
+            "commit": "d73b366a61f5a5692e4e3acc7df7282dd1d5b044",
+            "detail_url": "https://deskpro.github.io/releases/stable/2018-01/31909/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.14.2.31909/deskpro.zip",
+            "filesize": 225561692,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "1d535b7d",
+                "md5": "7da0a34967e15cb684d2fbd674fd94b7",
+                "sha1": "b400b7f889db8c41198f9ebd58456a4759c96c16",
+                "sha256": "812796f312add76b34e0609c4d1f32f127fe0bab709bd84c5d5331d455936618"
+            }
         }
     ]
 }

--- a/releases/stable/2018-01/31909/release.json
+++ b/releases/stable/2018-01/31909/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "31909",
+    "name": "5.14.2.31909",
+    "date": "2018-01-03 10:46:40",
+    "track": "stable",
+    "commit": "d73b366a61f5a5692e4e3acc7df7282dd1d5b044",
+    "detail_url": "https://deskpro.github.io/releases/stable/2018-01/31909/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.14.2.31909/deskpro.zip",
+    "filesize": 225561692,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "1d535b7d",
+        "md5": "7da0a34967e15cb684d2fbd674fd94b7",
+        "sha1": "b400b7f889db8c41198f9ebd58456a4759c96c16",
+        "sha256": "812796f312add76b34e0609c4d1f32f127fe0bab709bd84c5d5331d455936618"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.14.2.31909.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#31909](http://builder.deskprodemo.com/build/31909/)
