### PR TITLE
Release 5.15.1.32500

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1538,6 +1538,25 @@
                 "sha1": "c836f5a9bdcb07504395ac6d33c0993386e0b1df",
                 "sha256": "3d2bb60ad2b1a2eb957cd2daca95ea83b326cd97db87935e47d41deb36b2621c"
             }
+        },
+        {
+            "id": "32500",
+            "name": "5.15.1.32500",
+            "date": "2018-02-20 09:32:49",
+            "track": "stable",
+            "commit": "2e030148744e99097543a861da2da6cefdd26378",
+            "detail_url": "https://deskpro.github.io/releases/stable/2018-02/32500/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.15.1.32500/deskpro.zip",
+            "filesize": 233248533,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "d4384a0b",
+                "md5": "aa34464a691dc4719966fbe068f91e31",
+                "sha1": "5fbb322763da69653f046529b3871a27a63658d6",
+                "sha256": "454c59fbb600cbe5d5ce8f00f206a52c075fcb22d8fe6d7afa630b0e75d52559"
+            }
         }
     ]
 }

--- a/releases/stable/2018-02/32500/release.json
+++ b/releases/stable/2018-02/32500/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "32500",
+    "name": "5.15.1.32500",
+    "date": "2018-02-20 09:32:49",
+    "track": "stable",
+    "commit": "2e030148744e99097543a861da2da6cefdd26378",
+    "detail_url": "https://deskpro.github.io/releases/stable/2018-02/32500/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/5.15.1.32500/deskpro.zip",
+    "filesize": 233248533,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "d4384a0b",
+        "md5": "aa34464a691dc4719966fbe068f91e31",
+        "sha1": "5fbb322763da69653f046529b3871a27a63658d6",
+        "sha256": "454c59fbb600cbe5d5ce8f00f206a52c075fcb22d8fe6d7afa630b0e75d52559"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 5.15.1.32500.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#32500](http://builder.deskprodemo.com/build/32500/)
