### PR TITLE
Release 2018.1.33747

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1709,6 +1709,25 @@
                 "sha1": "5489db8ebe44959b74beaece2ee1fe1478fb22a1",
                 "sha256": "317bbac41460a0a647098da99b96c48ac51fbcd12a6adfd8f85757a9b07c62bd"
             }
+        },
+        {
+            "id": "33747",
+            "name": "2018.1.33747",
+            "date": "2018-05-21 11:00:42",
+            "track": "stable",
+            "commit": "51767a3f9e1535a02f8341c5a4f7c4021024249f",
+            "detail_url": "https://deskpro.github.io/releases/stable/2018-05/33747/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.1.33747/deskpro.zip",
+            "filesize": 205749605,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "9d55c50d",
+                "md5": "3404f886af711842293bb289db46182a",
+                "sha1": "0a5f9b4254c3e4fb88b9576a427725c9bb87bd28",
+                "sha256": "f7d52cc49800b67c0702748c2f769941ff8652eecb45ae8ce86a0b756ddfd093"
+            }
         }
     ]
 }

--- a/releases/stable/2018-05/33747/release.json
+++ b/releases/stable/2018-05/33747/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "33747",
+    "name": "2018.1.33747",
+    "date": "2018-05-21 11:00:42",
+    "track": "stable",
+    "commit": "51767a3f9e1535a02f8341c5a4f7c4021024249f",
+    "detail_url": "https://deskpro.github.io/releases/stable/2018-05/33747/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.1.33747/deskpro.zip",
+    "filesize": 205749605,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "9d55c50d",
+        "md5": "3404f886af711842293bb289db46182a",
+        "sha1": "0a5f9b4254c3e4fb88b9576a427725c9bb87bd28",
+        "sha256": "f7d52cc49800b67c0702748c2f769941ff8652eecb45ae8ce86a0b756ddfd093"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2018.1.33747.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#33747](http://builder.deskprodemo.com/build/33747/)
