### PR TITLE
Release 2018.1.33749

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1709,6 +1709,25 @@
                 "sha1": "5489db8ebe44959b74beaece2ee1fe1478fb22a1",
                 "sha256": "317bbac41460a0a647098da99b96c48ac51fbcd12a6adfd8f85757a9b07c62bd"
             }
+        },
+        {
+            "id": "33749",
+            "name": "2018.1.33749",
+            "date": "2018-05-21 11:36:52",
+            "track": "stable",
+            "commit": "13e1d17e4b5c298d68dfe8f00738534093727848",
+            "detail_url": "https://deskpro.github.io/releases/stable/2018-05/33749/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.1.33749/deskpro.zip",
+            "filesize": 205749198,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "49d80848",
+                "md5": "de649c5928d752f4707117455e11086f",
+                "sha1": "8d65d9c329f984cdd8c7ae2d892a35766910c7ab",
+                "sha256": "51b0ee3c954c977fecdbc321079ba5a7aab447bf48ed0a6ce9580b82a25f4e0d"
+            }
         }
     ]
 }

--- a/releases/stable/2018-05/33749/release.json
+++ b/releases/stable/2018-05/33749/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "33749",
+    "name": "2018.1.33749",
+    "date": "2018-05-21 11:36:52",
+    "track": "stable",
+    "commit": "13e1d17e4b5c298d68dfe8f00738534093727848",
+    "detail_url": "https://deskpro.github.io/releases/stable/2018-05/33749/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.1.33749/deskpro.zip",
+    "filesize": 205749198,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "49d80848",
+        "md5": "de649c5928d752f4707117455e11086f",
+        "sha1": "8d65d9c329f984cdd8c7ae2d892a35766910c7ab",
+        "sha256": "51b0ee3c954c977fecdbc321079ba5a7aab447bf48ed0a6ce9580b82a25f4e0d"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2018.1.33749.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#33749](http://builder.deskprodemo.com/build/33749/)
