### PR TITLE
Release 2018.1.3.34105

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1785,6 +1785,25 @@
                 "sha1": "b4e4b644768e8f0269a69658813eb4913f9104f9",
                 "sha256": "c21fa75f89998bb1d9569061c340478e6270cda501eff2fe691b5e1b67065865"
             }
+        },
+        {
+            "id": "34105",
+            "name": "2018.1.3.34105",
+            "date": "2018-06-13 17:17:56",
+            "track": "stable",
+            "commit": "a0a96f97106e6f3b729dd1b3491d67700e6f4eb1",
+            "detail_url": "https://deskpro.github.io/releases/stable/2018-06/34105/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.1.3.34105/deskpro.zip",
+            "filesize": 205955377,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "30711fe5",
+                "md5": "7f6d294cf658804f43281f259b1e1efa",
+                "sha1": "b37f45b3758867de442fae6b681bee45d8f726fd",
+                "sha256": "5ee478f71d30b3e9307f96be1fbc17eac8532dfb71ed8cfcff0e65ddff750f89"
+            }
         }
     ]
 }

--- a/releases/stable/2018-06/34105/release.json
+++ b/releases/stable/2018-06/34105/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "34105",
+    "name": "2018.1.3.34105",
+    "date": "2018-06-13 17:17:56",
+    "track": "stable",
+    "commit": "a0a96f97106e6f3b729dd1b3491d67700e6f4eb1",
+    "detail_url": "https://deskpro.github.io/releases/stable/2018-06/34105/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.1.3.34105/deskpro.zip",
+    "filesize": 205955377,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "30711fe5",
+        "md5": "7f6d294cf658804f43281f259b1e1efa",
+        "sha1": "b37f45b3758867de442fae6b681bee45d8f726fd",
+        "sha256": "5ee478f71d30b3e9307f96be1fbc17eac8532dfb71ed8cfcff0e65ddff750f89"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2018.1.3.34105.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#34105](http://builder.deskprodemo.com/build/34105/)
