### PR TITLE
Release 2018.2.1.34652

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1880,6 +1880,25 @@
                 "sha1": "77b956ee697220da671ad01f71f6d2628ae9e8f8",
                 "sha256": "3534750ef3e59e575a84c80f724c2b39bbf986e48d92cecedf0abc34d40445ee"
             }
+        },
+        {
+            "id": "34652",
+            "name": "2018.2.1.34652",
+            "date": "2018-07-26 11:20:00",
+            "track": "stable",
+            "commit": "188bb13f318a3b6658d118ef0e045af4db3a8d83",
+            "detail_url": "https://deskpro.github.io/releases/stable/2018-07/34652/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.2.1.34652/deskpro.zip",
+            "filesize": 218390516,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "e7b7b6d8",
+                "md5": "eec7b14234ee6d86335b70b23584d05d",
+                "sha1": "43d4d99490e58618191d1f85e36c952e8f38f123",
+                "sha256": "b04fb9cb54dc02bb059d70b0f722434f7ad79b552eb6e406e02ddbffb0d4c78d"
+            }
         }
     ]
 }

--- a/releases/stable/2018-07/34652/release.json
+++ b/releases/stable/2018-07/34652/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "34652",
+    "name": "2018.2.1.34652",
+    "date": "2018-07-26 11:20:00",
+    "track": "stable",
+    "commit": "188bb13f318a3b6658d118ef0e045af4db3a8d83",
+    "detail_url": "https://deskpro.github.io/releases/stable/2018-07/34652/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.2.1.34652/deskpro.zip",
+    "filesize": 218390516,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "e7b7b6d8",
+        "md5": "eec7b14234ee6d86335b70b23584d05d",
+        "sha1": "43d4d99490e58618191d1f85e36c952e8f38f123",
+        "sha256": "b04fb9cb54dc02bb059d70b0f722434f7ad79b552eb6e406e02ddbffb0d4c78d"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2018.2.1.34652.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#34652](http://builder.deskprodemo.com/build/34652/)
