### PR TITLE
Release 2018.2.1.34670

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -1880,6 +1880,25 @@
                 "sha1": "77b956ee697220da671ad01f71f6d2628ae9e8f8",
                 "sha256": "3534750ef3e59e575a84c80f724c2b39bbf986e48d92cecedf0abc34d40445ee"
             }
+        },
+        {
+            "id": "34670",
+            "name": "2018.2.1.34670",
+            "date": "2018-07-27 16:25:25",
+            "track": "stable",
+            "commit": "878655b678c7d6e3e460854e03dea163b0d0c507",
+            "detail_url": "https://deskpro.github.io/releases/stable/2018-07/34670/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.2.1.34670/deskpro.zip",
+            "filesize": 218390560,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "d61d8d93",
+                "md5": "2815fd86450212eb3c8e0860d2f4ff3c",
+                "sha1": "380e2e2a4f0ab3609a2dceba240169fa2bcaae04",
+                "sha256": "06970d66e0e7aee4174d6634eca8c72d99721d646b11c8362b622e1165cac8e7"
+            }
         }
     ]
 }

--- a/releases/stable/2018-07/34670/release.json
+++ b/releases/stable/2018-07/34670/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "34670",
+    "name": "2018.2.1.34670",
+    "date": "2018-07-27 16:25:25",
+    "track": "stable",
+    "commit": "878655b678c7d6e3e460854e03dea163b0d0c507",
+    "detail_url": "https://deskpro.github.io/releases/stable/2018-07/34670/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.2.1.34670/deskpro.zip",
+    "filesize": 218390560,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "d61d8d93",
+        "md5": "2815fd86450212eb3c8e0860d2f4ff3c",
+        "sha1": "380e2e2a4f0ab3609a2dceba240169fa2bcaae04",
+        "sha256": "06970d66e0e7aee4174d6634eca8c72d99721d646b11c8362b622e1165cac8e7"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2018.2.1.34670.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#34670](http://builder.deskprodemo.com/build/34670/)
