### PR TITLE
Release 2018.3.1.35740

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2013,6 +2013,25 @@
                 "sha1": "9d76308abe653323f843ac9eb18a8bcc6bf23279",
                 "sha256": "3e62df5c457222e5fb2fa6ad04e0ff50ef41f92904554807cb8f7fc77617fea3"
             }
+        },
+        {
+            "id": "35740",
+            "name": "2018.3.1.35740",
+            "date": "2018-10-17 11:16:17",
+            "track": "stable",
+            "commit": "eab04b06e83f312e2f9e4385d45b0b69247a82eb",
+            "detail_url": "https://deskpro.github.io/releases/stable/2018-10/35740/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.3.1.35740/deskpro.zip",
+            "filesize": 224935389,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "4ec56305",
+                "md5": "f90ae5d9e3679e652068263979614564",
+                "sha1": "e28748339714f2579e8a40976897f7cdaa271ac7",
+                "sha256": "cf9991de96573778e5f9be284c807a20ff25abcf17a71bef2dba6a1f6653738d"
+            }
         }
     ]
 }

--- a/releases/stable/2018-10/35740/release.json
+++ b/releases/stable/2018-10/35740/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "35740",
+    "name": "2018.3.1.35740",
+    "date": "2018-10-17 11:16:17",
+    "track": "stable",
+    "commit": "eab04b06e83f312e2f9e4385d45b0b69247a82eb",
+    "detail_url": "https://deskpro.github.io/releases/stable/2018-10/35740/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.3.1.35740/deskpro.zip",
+    "filesize": 224935389,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "4ec56305",
+        "md5": "f90ae5d9e3679e652068263979614564",
+        "sha1": "e28748339714f2579e8a40976897f7cdaa271ac7",
+        "sha256": "cf9991de96573778e5f9be284c807a20ff25abcf17a71bef2dba6a1f6653738d"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2018.3.1.35740.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#35740](http://builder.deskprodemo.com/build/35740/)
