### PR TITLE
Release 2018.3.3.36131

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2051,6 +2051,25 @@
                 "sha1": "13a7549dcc0e146af1850bb3c1de0ba5598270f9",
                 "sha256": "7411594ba9acc3466b674ae53b00de789862659f3c1eb0399e287103b0d3d182"
             }
+        },
+        {
+            "id": "36131",
+            "name": "2018.3.3.36131",
+            "date": "2018-11-15 11:35:00",
+            "track": "stable",
+            "commit": "308053f3d931bdf0660a81c1c12ab721b6ca8fea",
+            "detail_url": "https://deskpro.github.io/releases/stable/2018-11/36131/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.3.3.36131/deskpro.zip",
+            "filesize": 218817711,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "5ed96cca",
+                "md5": "6d1dd50d28180f8e9979fc49f1f7d97a",
+                "sha1": "a9205199d1d825d3b389c4fbb63d6941b7a03175",
+                "sha256": "d6853455d07a2849747d537861078c308218a2a093cd990d772d3b16fe0852fe"
+            }
         }
     ]
 }

--- a/releases/stable/2018-11/36131/release.json
+++ b/releases/stable/2018-11/36131/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "36131",
+    "name": "2018.3.3.36131",
+    "date": "2018-11-15 11:35:00",
+    "track": "stable",
+    "commit": "308053f3d931bdf0660a81c1c12ab721b6ca8fea",
+    "detail_url": "https://deskpro.github.io/releases/stable/2018-11/36131/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.3.3.36131/deskpro.zip",
+    "filesize": 218817711,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "5ed96cca",
+        "md5": "6d1dd50d28180f8e9979fc49f1f7d97a",
+        "sha1": "a9205199d1d825d3b389c4fbb63d6941b7a03175",
+        "sha256": "d6853455d07a2849747d537861078c308218a2a093cd990d772d3b16fe0852fe"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2018.3.3.36131.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#36131](http://builder.deskprodemo.com/build/36131/)
