### PR TITLE
Release 2018.3.3.36148

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2051,6 +2051,25 @@
                 "sha1": "13a7549dcc0e146af1850bb3c1de0ba5598270f9",
                 "sha256": "7411594ba9acc3466b674ae53b00de789862659f3c1eb0399e287103b0d3d182"
             }
+        },
+        {
+            "id": "36148",
+            "name": "2018.3.3.36148",
+            "date": "2018-11-15 16:09:53",
+            "track": "stable",
+            "commit": "13922edb00422059952e81604735a442e8d22a65",
+            "detail_url": "https://deskpro.github.io/releases/stable/2018-11/36148/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.3.3.36148/deskpro.zip",
+            "filesize": 218516297,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "e0f1aac2",
+                "md5": "978ab5d5e551bb058ba3fec37b15b400",
+                "sha1": "889d10e0354d35fa4aa56b6a7faee6c013c86db1",
+                "sha256": "b6b374a972a5607584575fadfdff0cbee975e0236601009005e26049e63099a2"
+            }
         }
     ]
 }

--- a/releases/stable/2018-11/36148/release.json
+++ b/releases/stable/2018-11/36148/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "36148",
+    "name": "2018.3.3.36148",
+    "date": "2018-11-15 16:09:53",
+    "track": "stable",
+    "commit": "13922edb00422059952e81604735a442e8d22a65",
+    "detail_url": "https://deskpro.github.io/releases/stable/2018-11/36148/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.3.3.36148/deskpro.zip",
+    "filesize": 218516297,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "e0f1aac2",
+        "md5": "978ab5d5e551bb058ba3fec37b15b400",
+        "sha1": "889d10e0354d35fa4aa56b6a7faee6c013c86db1",
+        "sha256": "b6b374a972a5607584575fadfdff0cbee975e0236601009005e26049e63099a2"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2018.3.3.36148.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#36148](http://builder.deskprodemo.com/build/36148/)
