### PR TITLE
Release 2018.3.4.36345

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2070,6 +2070,25 @@
                 "sha1": "889d10e0354d35fa4aa56b6a7faee6c013c86db1",
                 "sha256": "b6b374a972a5607584575fadfdff0cbee975e0236601009005e26049e63099a2"
             }
+        },
+        {
+            "id": "36345",
+            "name": "2018.3.4.36345",
+            "date": "2018-11-29 12:03:07",
+            "track": "stable",
+            "commit": "9bbb39e2b346d4817bdc1802ad6f7149387e8432",
+            "detail_url": "https://deskpro.github.io/releases/stable/2018-11/36345/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.3.4.36345/deskpro.zip",
+            "filesize": 218516330,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "8dfd5c4e",
+                "md5": "b6b63d18fedec559208e15f605f87366",
+                "sha1": "c8b6600ae0afbd2ffd994ebf7fa3d132587d0631",
+                "sha256": "a5f6fcdde3a4373c90236a1e7dbb2d926f1160a871d3867cfcdb9b444cf31df0"
+            }
         }
     ]
 }

--- a/releases/stable/2018-11/36345/release.json
+++ b/releases/stable/2018-11/36345/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "36345",
+    "name": "2018.3.4.36345",
+    "date": "2018-11-29 12:03:07",
+    "track": "stable",
+    "commit": "9bbb39e2b346d4817bdc1802ad6f7149387e8432",
+    "detail_url": "https://deskpro.github.io/releases/stable/2018-11/36345/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2018.3.4.36345/deskpro.zip",
+    "filesize": 218516330,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "8dfd5c4e",
+        "md5": "b6b63d18fedec559208e15f605f87366",
+        "sha1": "c8b6600ae0afbd2ffd994ebf7fa3d132587d0631",
+        "sha256": "a5f6fcdde3a4373c90236a1e7dbb2d926f1160a871d3867cfcdb9b444cf31df0"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2018.3.4.36345.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#36345](http://builder.deskprodemo.com/build/36345/)
