### PR TITLE
Release 2019.1.36734

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2089,6 +2089,25 @@
                 "sha1": "c8b6600ae0afbd2ffd994ebf7fa3d132587d0631",
                 "sha256": "a5f6fcdde3a4373c90236a1e7dbb2d926f1160a871d3867cfcdb9b444cf31df0"
             }
+        },
+        {
+            "id": "36734",
+            "name": "2019.1.36734",
+            "date": "2019-01-08 11:09:50",
+            "track": "stable",
+            "commit": "17f79d05f509bd2e3aebe4fada2ce09ef1a85405",
+            "detail_url": "https://deskpro.github.io/releases/stable/2019-01/36734/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.1.36734/deskpro.zip",
+            "filesize": 218448840,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "5b8be942",
+                "md5": "9c6751f009934506346907ec807ca293",
+                "sha1": "27c3b815db81c72cee0a6c2a978cf2c2801c8fad",
+                "sha256": "1731686442afa5fe1bb4159957dc0f5b16d630f59b1e7edcc41a096950a5e1d5"
+            }
         }
     ]
 }

--- a/releases/stable/2019-01/36734/release.json
+++ b/releases/stable/2019-01/36734/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "36734",
+    "name": "2019.1.36734",
+    "date": "2019-01-08 11:09:50",
+    "track": "stable",
+    "commit": "17f79d05f509bd2e3aebe4fada2ce09ef1a85405",
+    "detail_url": "https://deskpro.github.io/releases/stable/2019-01/36734/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.1.36734/deskpro.zip",
+    "filesize": 218448840,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "5b8be942",
+        "md5": "9c6751f009934506346907ec807ca293",
+        "sha1": "27c3b815db81c72cee0a6c2a978cf2c2801c8fad",
+        "sha256": "1731686442afa5fe1bb4159957dc0f5b16d630f59b1e7edcc41a096950a5e1d5"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2019.1.36734.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#36734](http://builder.deskprodemo.com/build/36734/)
