### PR TITLE
Release 2019.1.36769

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2108,6 +2108,25 @@
                 "sha1": "871f40a76b92a41394ab8a76407164017659d34f",
                 "sha256": "e05de26fc76e3d470cedf7db203f9e1ad3a87c8e80381deee268698f1ae4896b"
             }
+        },
+        {
+            "id": "36769",
+            "name": "2019.1.36769",
+            "date": "2019-01-09 18:03:30",
+            "track": "stable",
+            "commit": "de3ee9ed20dbbea473dda18790d29f56a6695dd9",
+            "detail_url": "https://deskpro.github.io/releases/stable/2019-01/36769/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.1.36769/deskpro.zip",
+            "filesize": 218450492,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "9dd17350",
+                "md5": "81be483e5cc673a1448ec9c632c77e64",
+                "sha1": "91eef5e535d26a46ff4c50de1fa1aaa58c5dfd32",
+                "sha256": "e69e124f31bb1cc6a5f1ecd80b286b494e6afa504ff96bd250eead3aca8188ca"
+            }
         }
     ]
 }

--- a/releases/stable/2019-01/36769/release.json
+++ b/releases/stable/2019-01/36769/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "36769",
+    "name": "2019.1.36769",
+    "date": "2019-01-09 18:03:30",
+    "track": "stable",
+    "commit": "de3ee9ed20dbbea473dda18790d29f56a6695dd9",
+    "detail_url": "https://deskpro.github.io/releases/stable/2019-01/36769/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.1.36769/deskpro.zip",
+    "filesize": 218450492,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "9dd17350",
+        "md5": "81be483e5cc673a1448ec9c632c77e64",
+        "sha1": "91eef5e535d26a46ff4c50de1fa1aaa58c5dfd32",
+        "sha256": "e69e124f31bb1cc6a5f1ecd80b286b494e6afa504ff96bd250eead3aca8188ca"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2019.1.36769.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#36769](http://builder.deskprodemo.com/build/36769/)
