### PR TITLE
Release 2019.1.3.36895

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2165,6 +2165,25 @@
                 "sha1": "418c94d4a13c089fc80456f110095acf0fc33fc9",
                 "sha256": "6c9e0381f4fbcf3245be62fbb0150ca08d2f157b21538cce62b4e8ca91ebb58b"
             }
+        },
+        {
+            "id": "36895",
+            "name": "2019.1.3.36895",
+            "date": "2019-01-22 11:14:07",
+            "track": "stable",
+            "commit": "9a5359d5dd0be590c53ee9253db4f111dffc4efd",
+            "detail_url": "https://deskpro.github.io/releases/stable/2019-01/36895/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.1.3.36895/deskpro.zip",
+            "filesize": 218449661,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "ddf0787e",
+                "md5": "8d11619671a878d95ef8bef0cda32d05",
+                "sha1": "3cb576672da64e34118e96d34af80e8b5442fedb",
+                "sha256": "d3ca1df4531849f42741c6dd04e80833f97dca81e6b6b822cb59aab23f48ca84"
+            }
         }
     ]
 }

--- a/releases/stable/2019-01/36895/release.json
+++ b/releases/stable/2019-01/36895/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "36895",
+    "name": "2019.1.3.36895",
+    "date": "2019-01-22 11:14:07",
+    "track": "stable",
+    "commit": "9a5359d5dd0be590c53ee9253db4f111dffc4efd",
+    "detail_url": "https://deskpro.github.io/releases/stable/2019-01/36895/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.1.3.36895/deskpro.zip",
+    "filesize": 218449661,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "ddf0787e",
+        "md5": "8d11619671a878d95ef8bef0cda32d05",
+        "sha1": "3cb576672da64e34118e96d34af80e8b5442fedb",
+        "sha256": "d3ca1df4531849f42741c6dd04e80833f97dca81e6b6b822cb59aab23f48ca84"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2019.1.3.36895.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#36895](http://builder.deskprodemo.com/build/36895/)
