### PR TITLE
Release 2019.5.0.38492

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2469,6 +2469,25 @@
                 "sha1": "6f47a7224cbac2bb2532969e9485c5461ecaa0a2",
                 "sha256": "9333d079cd8759b40c97bb53d2080cc698aebf078c194955d844208fc5ba6155"
             }
+        },
+        {
+            "id": "38492",
+            "name": "2019.5.0.38492",
+            "date": "2019-05-15 09:17:06",
+            "track": "stable",
+            "commit": "a65d7548312add7e4d1396084f75d8b40afd9e61",
+            "detail_url": "https://deskpro.github.io/releases/stable/2019-05/38492/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.5.0.38492/deskpro.zip",
+            "filesize": 248096073,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "cf1bf4bf",
+                "md5": "e41181a056d00b370fb4346f8db6ea5b",
+                "sha1": "be8622d7e9ff8c937393f33d9843e85941cf767f",
+                "sha256": "2c2991771a39549558b2b9ed95c77341d2f3fc146279cb665d2dbfe98381eda6"
+            }
         }
     ]
 }

--- a/releases/stable/2019-05/38492/release.json
+++ b/releases/stable/2019-05/38492/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "38492",
+    "name": "2019.5.0.38492",
+    "date": "2019-05-15 09:17:06",
+    "track": "stable",
+    "commit": "a65d7548312add7e4d1396084f75d8b40afd9e61",
+    "detail_url": "https://deskpro.github.io/releases/stable/2019-05/38492/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.5.0.38492/deskpro.zip",
+    "filesize": 248096073,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "cf1bf4bf",
+        "md5": "e41181a056d00b370fb4346f8db6ea5b",
+        "sha1": "be8622d7e9ff8c937393f33d9843e85941cf767f",
+        "sha256": "2c2991771a39549558b2b9ed95c77341d2f3fc146279cb665d2dbfe98381eda6"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2019.5.0.38492.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#38492](http://builder.deskprodemo.com/build/38492/)
