### PR TITLE
Release 2019.5.1.38494

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2469,6 +2469,25 @@
                 "sha1": "6f47a7224cbac2bb2532969e9485c5461ecaa0a2",
                 "sha256": "9333d079cd8759b40c97bb53d2080cc698aebf078c194955d844208fc5ba6155"
             }
+        },
+        {
+            "id": "38494",
+            "name": "2019.5.1.38494",
+            "date": "2019-05-15 11:34:28",
+            "track": "stable",
+            "commit": "e8eb3ce12725be514cc2f6828f107f050ba07e8a",
+            "detail_url": "https://deskpro.github.io/releases/stable/2019-05/38494/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.5.1.38494/deskpro.zip",
+            "filesize": 248094833,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "5ad050be",
+                "md5": "cae5302bc978e2be12526a99a0c701c9",
+                "sha1": "aaac18dbd05f3ff3ecaf9b9a01645a15b2909ee2",
+                "sha256": "b53d88dba33aae3d09514e46740c06b2b25d460840d1ecb6fcadd4a05cb9b55f"
+            }
         }
     ]
 }

--- a/releases/stable/2019-05/38494/release.json
+++ b/releases/stable/2019-05/38494/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "38494",
+    "name": "2019.5.1.38494",
+    "date": "2019-05-15 11:34:28",
+    "track": "stable",
+    "commit": "e8eb3ce12725be514cc2f6828f107f050ba07e8a",
+    "detail_url": "https://deskpro.github.io/releases/stable/2019-05/38494/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.5.1.38494/deskpro.zip",
+    "filesize": 248094833,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "5ad050be",
+        "md5": "cae5302bc978e2be12526a99a0c701c9",
+        "sha1": "aaac18dbd05f3ff3ecaf9b9a01645a15b2909ee2",
+        "sha256": "b53d88dba33aae3d09514e46740c06b2b25d460840d1ecb6fcadd4a05cb9b55f"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2019.5.1.38494.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#38494](http://builder.deskprodemo.com/build/38494/)
