### PR TITLE
Release 2019.7.0.40032

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2564,6 +2564,25 @@
                 "sha1": "7103b3d26cac2cc7881c542ef6f73f500e85a3e5",
                 "sha256": "a5a8a895a183ff24a58c7ce0b8d05d480c307e475c48d519cb81d751786a12c1"
             }
+        },
+        {
+            "id": "40032",
+            "name": "2019.7.0.40032",
+            "date": "2019-09-02 09:15:40",
+            "track": "stable",
+            "commit": "1324cacea3fe8b0f3e917ea901cf12f81d32ab48",
+            "detail_url": "https://deskpro.github.io/releases/stable/2019-09/40032/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.7.0.40032/deskpro.zip",
+            "filesize": 254612041,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "d58f9d87",
+                "md5": "581f8d0e226d92113d978bf4d520ed29",
+                "sha1": "0dea29e8e6bdf40141d011ad81e60efa687c4bd8",
+                "sha256": "3ea8ec5aace78dbf5112bf04389d672c2df663026c14d9c90b69630316322c1b"
+            }
         }
     ]
 }

--- a/releases/stable/2019-09/40032/release.json
+++ b/releases/stable/2019-09/40032/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "40032",
+    "name": "2019.7.0.40032",
+    "date": "2019-09-02 09:15:40",
+    "track": "stable",
+    "commit": "1324cacea3fe8b0f3e917ea901cf12f81d32ab48",
+    "detail_url": "https://deskpro.github.io/releases/stable/2019-09/40032/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2019.7.0.40032/deskpro.zip",
+    "filesize": 254612041,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "d58f9d87",
+        "md5": "581f8d0e226d92113d978bf4d520ed29",
+        "sha1": "0dea29e8e6bdf40141d011ad81e60efa687c4bd8",
+        "sha256": "3ea8ec5aace78dbf5112bf04389d672c2df663026c14d9c90b69630316322c1b"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2019.7.0.40032.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#40032](http://builder.deskprodemo.com/build/40032/)
