### PR TITLE
Release 2020.0.1.43914

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2906,6 +2906,25 @@
                 "sha1": "38c83c8725c158681b71829e2d5553b352f9c552",
                 "sha256": "7ddfa29cb7ff895ed33bf2074dcdcf8e8f3bef108619b3d6aa4fdcf76b5745f8"
             }
+        },
+        {
+            "id": "43914",
+            "name": "2020.0.1.43914",
+            "date": "2020-03-24 12:36:37",
+            "track": "stable",
+            "commit": "fbd75872589d6d75845c235cfd64dc333cff75c1",
+            "detail_url": "https://deskpro.github.io/releases/stable/2020-03/43914/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.0.1.43914/deskpro.zip",
+            "filesize": 289998069,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "b990f4a5",
+                "md5": "3bc1167434b3eb8c79d4b9b5c32369e9",
+                "sha1": "28ee946722e72cabbd18cb031ca6427f33340121",
+                "sha256": "9842c206aada648d1f294e865d62705e913e1e45e30475c5f83598be26b1b023"
+            }
         }
     ]
 }

--- a/releases/stable/2020-03/43914/release.json
+++ b/releases/stable/2020-03/43914/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "43914",
+    "name": "2020.0.1.43914",
+    "date": "2020-03-24 12:36:37",
+    "track": "stable",
+    "commit": "fbd75872589d6d75845c235cfd64dc333cff75c1",
+    "detail_url": "https://deskpro.github.io/releases/stable/2020-03/43914/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.0.1.43914/deskpro.zip",
+    "filesize": 289998069,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "b990f4a5",
+        "md5": "3bc1167434b3eb8c79d4b9b5c32369e9",
+        "sha1": "28ee946722e72cabbd18cb031ca6427f33340121",
+        "sha256": "9842c206aada648d1f294e865d62705e913e1e45e30475c5f83598be26b1b023"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2020.0.1.43914.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#43914](http://builder.deskprodemo.com/build/43914/)
