### PR TITLE
Release 2020.1.3.45717

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -2982,6 +2982,25 @@
                 "sha1": "4208ab385259baec7162ea027367891b2acf3173",
                 "sha256": "e93e3100a732580e20264c75e0975cd054216276ddd2f10fcbb1adb07f493101"
             }
+        },
+        {
+            "id": "45717",
+            "name": "2020.1.3.45717",
+            "date": "2020-05-19 08:22:00",
+            "track": "stable",
+            "commit": "7c0f5f66f1f6965e6478879cab422e81844cccb5",
+            "detail_url": "https://deskpro.github.io/releases/stable/2020-05/45717/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.1.3.45717/deskpro.zip",
+            "filesize": 292826189,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "3fb6a3cd",
+                "md5": "2e92d92d69819419d2216a67203a182c",
+                "sha1": "2e9eb10ffa8118b85c0d8192a809b9760c30a2fd",
+                "sha256": "d8975025233a80c446d9edf56b2652bf44a270f8e501f34bfefe8b7ceacdaf66"
+            }
         }
     ]
 }

--- a/releases/stable/2020-05/45717/release.json
+++ b/releases/stable/2020-05/45717/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "45717",
+    "name": "2020.1.3.45717",
+    "date": "2020-05-19 08:22:00",
+    "track": "stable",
+    "commit": "7c0f5f66f1f6965e6478879cab422e81844cccb5",
+    "detail_url": "https://deskpro.github.io/releases/stable/2020-05/45717/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.1.3.45717/deskpro.zip",
+    "filesize": 292826189,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "3fb6a3cd",
+        "md5": "2e92d92d69819419d2216a67203a182c",
+        "sha1": "2e9eb10ffa8118b85c0d8192a809b9760c30a2fd",
+        "sha256": "d8975025233a80c446d9edf56b2652bf44a270f8e501f34bfefe8b7ceacdaf66"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2020.1.3.45717.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#45717](http://builder.deskprodemo.com/build/45717/)
