### PR TITLE
Release 2020.2.0.48120

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3115,6 +3115,25 @@
                 "sha1": "81d89e434aa062de686e9923a6005970eebc661d",
                 "sha256": "90c6915050cec78b40924a030ae8f034cf3048df87ef75d22d58dc0e8e0c5afd"
             }
+        },
+        {
+            "id": "48120",
+            "name": "2020.2.0.48120",
+            "date": "2020-07-21 12:31:03",
+            "track": "stable",
+            "commit": "b7d75b54e631738f16e93443bfd1d3203212ee51",
+            "detail_url": "https://deskpro.github.io/releases/stable/2020-07/48120/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.0.48120/deskpro.zip",
+            "filesize": 293941543,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "8e4aa64b",
+                "md5": "05a41abc228f15861204626926c85f44",
+                "sha1": "15624325d411b1d747f57416b1f7f9e55671fe90",
+                "sha256": "5e6f193ee54c72cce0a08b60cf0ffa10fe53c481c48419f9f01b1cdb6639405f"
+            }
         }
     ]
 }

--- a/releases/stable/2020-07/48120/release.json
+++ b/releases/stable/2020-07/48120/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "48120",
+    "name": "2020.2.0.48120",
+    "date": "2020-07-21 12:31:03",
+    "track": "stable",
+    "commit": "b7d75b54e631738f16e93443bfd1d3203212ee51",
+    "detail_url": "https://deskpro.github.io/releases/stable/2020-07/48120/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.0.48120/deskpro.zip",
+    "filesize": 293941543,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "8e4aa64b",
+        "md5": "05a41abc228f15861204626926c85f44",
+        "sha1": "15624325d411b1d747f57416b1f7f9e55671fe90",
+        "sha256": "5e6f193ee54c72cce0a08b60cf0ffa10fe53c481c48419f9f01b1cdb6639405f"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2020.2.0.48120.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#48120](http://builder.deskprodemo.com/build/48120/)
