### PR TITLE
Release 2020.2.1.48169

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3153,6 +3153,25 @@
                 "sha1": "dc07f4f46f24f14d08e45ae42ba886eacb31275c",
                 "sha256": "0116fcb743b951caadc0090677737bfb36946ef1037e61bfd02f2a89d973c828"
             }
+        },
+        {
+            "id": "48169",
+            "name": "2020.2.1.48169",
+            "date": "2020-07-27 14:48:04",
+            "track": "stable",
+            "commit": "757e4906d5e8e8c4b39d105fccbfb6c6ea1fdd3b",
+            "detail_url": "https://deskpro.github.io/releases/stable/2020-07/48169/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.1.48169/deskpro.zip",
+            "filesize": 293935555,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "4eef0fb2",
+                "md5": "eef5b613828a37045f15d38325713682",
+                "sha1": "2cde8bf7a675d0971ac72bac50bbdb0d57bec2e7",
+                "sha256": "9dab1345498328625bb811ba429f99848924f6af977c02993b5f2a2205579354"
+            }
         }
     ]
 }

--- a/releases/stable/2020-07/48169/release.json
+++ b/releases/stable/2020-07/48169/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "48169",
+    "name": "2020.2.1.48169",
+    "date": "2020-07-27 14:48:04",
+    "track": "stable",
+    "commit": "757e4906d5e8e8c4b39d105fccbfb6c6ea1fdd3b",
+    "detail_url": "https://deskpro.github.io/releases/stable/2020-07/48169/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.1.48169/deskpro.zip",
+    "filesize": 293935555,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "4eef0fb2",
+        "md5": "eef5b613828a37045f15d38325713682",
+        "sha1": "2cde8bf7a675d0971ac72bac50bbdb0d57bec2e7",
+        "sha256": "9dab1345498328625bb811ba429f99848924f6af977c02993b5f2a2205579354"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2020.2.1.48169.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#48169](http://builder.deskprodemo.com/build/48169/)
