### PR TITLE
Release 2020.2.5.48428

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3229,6 +3229,25 @@
                 "sha1": "1a7f1fc7652ee7b6837f093eb07fce944cbe84f8",
                 "sha256": "bf5695f5b719f1d1235d867510cb6fdd785b2fb8a527beb2e03dbc93199bd512"
             }
+        },
+        {
+            "id": "48428",
+            "name": "2020.2.5.48428",
+            "date": "2020-08-26 09:43:26",
+            "track": "stable",
+            "commit": "2dc405ff2c7a83f1084be6749e2acb5dac8060e2",
+            "detail_url": "https://deskpro.github.io/releases/stable/2020-08/48428/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.5.48428/deskpro.zip",
+            "filesize": 297547627,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "b91a54c3",
+                "md5": "a01fe51ba0a9a8c1fbfd657e0b3ab878",
+                "sha1": "322453cccbc42acf12374f414c9e96361963e5ce",
+                "sha256": "c92b2b116ddc2162d65829f05920aee133cd4d6d83c5d79093eceb68cb9e0006"
+            }
         }
     ]
 }

--- a/releases/stable/2020-08/48428/release.json
+++ b/releases/stable/2020-08/48428/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "48428",
+    "name": "2020.2.5.48428",
+    "date": "2020-08-26 09:43:26",
+    "track": "stable",
+    "commit": "2dc405ff2c7a83f1084be6749e2acb5dac8060e2",
+    "detail_url": "https://deskpro.github.io/releases/stable/2020-08/48428/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.5.48428/deskpro.zip",
+    "filesize": 297547627,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "b91a54c3",
+        "md5": "a01fe51ba0a9a8c1fbfd657e0b3ab878",
+        "sha1": "322453cccbc42acf12374f414c9e96361963e5ce",
+        "sha256": "c92b2b116ddc2162d65829f05920aee133cd4d6d83c5d79093eceb68cb9e0006"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2020.2.5.48428.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#48428](http://builder.deskprodemo.com/build/48428/)
