### PR TITLE
Release 2020.2.5.48436

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3229,6 +3229,25 @@
                 "sha1": "1a7f1fc7652ee7b6837f093eb07fce944cbe84f8",
                 "sha256": "bf5695f5b719f1d1235d867510cb6fdd785b2fb8a527beb2e03dbc93199bd512"
             }
+        },
+        {
+            "id": "48436",
+            "name": "2020.2.5.48436",
+            "date": "2020-08-26 14:07:46",
+            "track": "stable",
+            "commit": "78bbba560791aa63df262d45d82dca375ee9efb4",
+            "detail_url": "https://deskpro.github.io/releases/stable/2020-08/48436/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.5.48436/deskpro.zip",
+            "filesize": 297635579,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "67c18ccf",
+                "md5": "a32cd2abb1b604a80282ac3ae58287df",
+                "sha1": "899c08363f9831639cacba9545fa9e866687efc9",
+                "sha256": "c59ca94fe861f7d90aaafeed46a85d6d553fe54073d07df52f2b71410bc5ab63"
+            }
         }
     ]
 }

--- a/releases/stable/2020-08/48436/release.json
+++ b/releases/stable/2020-08/48436/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "48436",
+    "name": "2020.2.5.48436",
+    "date": "2020-08-26 14:07:46",
+    "track": "stable",
+    "commit": "78bbba560791aa63df262d45d82dca375ee9efb4",
+    "detail_url": "https://deskpro.github.io/releases/stable/2020-08/48436/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.5.48436/deskpro.zip",
+    "filesize": 297635579,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "67c18ccf",
+        "md5": "a32cd2abb1b604a80282ac3ae58287df",
+        "sha1": "899c08363f9831639cacba9545fa9e866687efc9",
+        "sha256": "c59ca94fe861f7d90aaafeed46a85d6d553fe54073d07df52f2b71410bc5ab63"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2020.2.5.48436.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#48436](http://builder.deskprodemo.com/build/48436/)
