### PR TITLE
Release 2020.2.8.50101

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3305,6 +3305,25 @@
                 "sha1": "b0c3495d139ba8bc32cc837f4f95a84f3225f879",
                 "sha256": "4c58b48549587b999474de4ccbde2f5dcdf7897f61a9ccbaf9bb48d9f3624476"
             }
+        },
+        {
+            "id": "50101",
+            "name": "2020.2.8.50101",
+            "date": "2020-10-19 11:38:20",
+            "track": "stable",
+            "commit": "7821928b1f99f3eb72f5e2ae7ada619b6d219b26",
+            "detail_url": "https://deskpro.github.io/releases/stable/2020-10/50101/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.8.50101/deskpro.zip",
+            "filesize": 306766372,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "294c915c",
+                "md5": "61bdc96589b579be7b0a48dd8e1f8700",
+                "sha1": "2f404057647684fd02d6dfa27d04e6b4cc83b2a5",
+                "sha256": "9b9113d5b4b0cd7a280839ccc74d8442298ec7918bb051e48711ed3abe8af66b"
+            }
         }
     ]
 }

--- a/releases/stable/2020-10/50101/release.json
+++ b/releases/stable/2020-10/50101/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "50101",
+    "name": "2020.2.8.50101",
+    "date": "2020-10-19 11:38:20",
+    "track": "stable",
+    "commit": "7821928b1f99f3eb72f5e2ae7ada619b6d219b26",
+    "detail_url": "https://deskpro.github.io/releases/stable/2020-10/50101/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.8.50101/deskpro.zip",
+    "filesize": 306766372,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "294c915c",
+        "md5": "61bdc96589b579be7b0a48dd8e1f8700",
+        "sha1": "2f404057647684fd02d6dfa27d04e6b4cc83b2a5",
+        "sha256": "9b9113d5b4b0cd7a280839ccc74d8442298ec7918bb051e48711ed3abe8af66b"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2020.2.8.50101.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#50101](http://builder.deskprodemo.com/build/50101/)
