### PR TITLE
Release 2020.2.9.50136

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3324,6 +3324,25 @@
                 "sha1": "2f404057647684fd02d6dfa27d04e6b4cc83b2a5",
                 "sha256": "9b9113d5b4b0cd7a280839ccc74d8442298ec7918bb051e48711ed3abe8af66b"
             }
+        },
+        {
+            "id": "50136",
+            "name": "2020.2.9.50136",
+            "date": "2020-10-20 10:45:30",
+            "track": "stable",
+            "commit": "4c72381479793326b441618401b062570d417b80",
+            "detail_url": "https://deskpro.github.io/releases/stable/2020-10/50136/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.9.50136/deskpro.zip",
+            "filesize": 306794230,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "355fa443",
+                "md5": "b57b52c58c291d24f57d1c06181b71b3",
+                "sha1": "98968f446ab523c26e50ac845509603629da268d",
+                "sha256": "9704e4763ac6b927e01f93610c40c5a81d15af361fad0c80f0cf29c00958ffb2"
+            }
         }
     ]
 }

--- a/releases/stable/2020-10/50136/release.json
+++ b/releases/stable/2020-10/50136/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "50136",
+    "name": "2020.2.9.50136",
+    "date": "2020-10-20 10:45:30",
+    "track": "stable",
+    "commit": "4c72381479793326b441618401b062570d417b80",
+    "detail_url": "https://deskpro.github.io/releases/stable/2020-10/50136/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.9.50136/deskpro.zip",
+    "filesize": 306794230,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "355fa443",
+        "md5": "b57b52c58c291d24f57d1c06181b71b3",
+        "sha1": "98968f446ab523c26e50ac845509603629da268d",
+        "sha256": "9704e4763ac6b927e01f93610c40c5a81d15af361fad0c80f0cf29c00958ffb2"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2020.2.9.50136.

Branch: [develop](https://github.com/DeskPRO/DeskPRO/tree/develop)
Build details: [#50136](http://builder.deskprodemo.com/build/50136/)
