### PR TITLE
Release 2020.2.10.50355

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3343,6 +3343,25 @@
                 "sha1": "98968f446ab523c26e50ac845509603629da268d",
                 "sha256": "9704e4763ac6b927e01f93610c40c5a81d15af361fad0c80f0cf29c00958ffb2"
             }
+        },
+        {
+            "id": "50355",
+            "name": "2020.2.10.50355",
+            "date": "2020-10-29 22:25:45",
+            "track": "stable",
+            "commit": "bb7a802c38d0288d18add57c01026e7788f33a7a",
+            "detail_url": "https://deskpro.github.io/releases/stable/2020-10/50355/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.10.50355/deskpro.zip",
+            "filesize": 306792770,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "4dc8ad4f",
+                "md5": "8d45d014ce32f88fd5a0780a417b656d",
+                "sha1": "d71eb3d08dafb4198ff479da5c53d7039bbfe597",
+                "sha256": "fda85e9c43464ab56877862ba32e8f9a49e1b3cfe2446463cf520d7e38ba837f"
+            }
         }
     ]
 }

--- a/releases/stable/2020-10/50355/release.json
+++ b/releases/stable/2020-10/50355/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "50355",
+    "name": "2020.2.10.50355",
+    "date": "2020-10-29 22:25:45",
+    "track": "stable",
+    "commit": "bb7a802c38d0288d18add57c01026e7788f33a7a",
+    "detail_url": "https://deskpro.github.io/releases/stable/2020-10/50355/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.2.10.50355/deskpro.zip",
+    "filesize": 306792770,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "4dc8ad4f",
+        "md5": "8d45d014ce32f88fd5a0780a417b656d",
+        "sha1": "d71eb3d08dafb4198ff479da5c53d7039bbfe597",
+        "sha256": "fda85e9c43464ab56877862ba32e8f9a49e1b3cfe2446463cf520d7e38ba837f"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2020.2.10.50355.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#50355](http://builder.deskprodemo.com/build/50355/)
