### PR TITLE
Release 2020.3.50740

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3400,6 +3400,25 @@
                 "sha1": "f2b2405b45322383303e1f7106f58b9d6c85bfcf",
                 "sha256": "e8d34292cf946f11e6ec980fe37da69abdaac3ba978cce040f6ed4402e852e86"
             }
+        },
+        {
+            "id": "50740",
+            "name": "2020.3.50740",
+            "date": "2020-12-07 10:27:38",
+            "track": "stable",
+            "commit": "d1d5fabb6e008cc06da61d09da849dc00930379a",
+            "detail_url": "https://deskpro.github.io/releases/stable/2020-12/50740/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.3.50740/deskpro.zip",
+            "filesize": 308728304,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "cdcd3489",
+                "md5": "b4e3f5f3fc5f2ed73fb3e0cb7bea527b",
+                "sha1": "89f7a9639e315b5410ece40e18195f12f64bd4af",
+                "sha256": "24e7be6d39a74dc34d988e49d7b64cab9e38163703395f79eafd51e2bd66d18d"
+            }
         }
     ]
 }

--- a/releases/stable/2020-12/50740/release.json
+++ b/releases/stable/2020-12/50740/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "50740",
+    "name": "2020.3.50740",
+    "date": "2020-12-07 10:27:38",
+    "track": "stable",
+    "commit": "d1d5fabb6e008cc06da61d09da849dc00930379a",
+    "detail_url": "https://deskpro.github.io/releases/stable/2020-12/50740/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2020.3.50740/deskpro.zip",
+    "filesize": 308728304,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "cdcd3489",
+        "md5": "b4e3f5f3fc5f2ed73fb3e0cb7bea527b",
+        "sha1": "89f7a9639e315b5410ece40e18195f12f64bd4af",
+        "sha256": "24e7be6d39a74dc34d988e49d7b64cab9e38163703395f79eafd51e2bd66d18d"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2020.3.50740.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#50740](http://builder.deskprodemo.com/build/50740/)
