### PR TITLE
Release 2021.1.1.51116

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3438,6 +3438,25 @@
                 "sha1": "747e075620aac24930d8591d688b7e32b6e840a4",
                 "sha256": "ca4667b780e5c2951f5f357d7413c04267456c6ad2f44a6be1aec3d466790297"
             }
+        },
+        {
+            "id": "51116",
+            "name": "2021.1.1.51116",
+            "date": "2021-02-02 09:34:57",
+            "track": "stable",
+            "commit": "61e00fa5bd4a594fa999e4aacb7bf4ede26b3d42",
+            "detail_url": "https://deskpro.github.io/releases/stable/2021-02/51116/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.1.51116/deskpro.zip",
+            "filesize": 308871812,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "bab3134e",
+                "md5": "50656546f2af61a9377ef781db7281b2",
+                "sha1": "a693686f81e1fea5e30c56371f101e96313fe80f",
+                "sha256": "8e72ce5072d20ff29c54d2ef795d4d4969c0eeea200bbf1092fcbadfb7b91d72"
+            }
         }
     ]
 }

--- a/releases/stable/2021-02/51116/release.json
+++ b/releases/stable/2021-02/51116/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "51116",
+    "name": "2021.1.1.51116",
+    "date": "2021-02-02 09:34:57",
+    "track": "stable",
+    "commit": "61e00fa5bd4a594fa999e4aacb7bf4ede26b3d42",
+    "detail_url": "https://deskpro.github.io/releases/stable/2021-02/51116/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.1.51116/deskpro.zip",
+    "filesize": 308871812,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "bab3134e",
+        "md5": "50656546f2af61a9377ef781db7281b2",
+        "sha1": "a693686f81e1fea5e30c56371f101e96313fe80f",
+        "sha256": "8e72ce5072d20ff29c54d2ef795d4d4969c0eeea200bbf1092fcbadfb7b91d72"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2021.1.1.51116.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#51116](http://builder.deskprodemo.com/build/51116/)
