### PR TITLE
Release 2021.1.2.51391

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3457,6 +3457,25 @@
                 "sha1": "a693686f81e1fea5e30c56371f101e96313fe80f",
                 "sha256": "8e72ce5072d20ff29c54d2ef795d4d4969c0eeea200bbf1092fcbadfb7b91d72"
             }
+        },
+        {
+            "id": "51391",
+            "name": "2021.1.2.51391",
+            "date": "2021-03-11 11:50:28",
+            "track": "stable",
+            "commit": "b831aaad02ec00736c80b0359b54a430a86f4c0c",
+            "detail_url": "https://deskpro.github.io/releases/stable/2021-03/51391/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.2.51391/deskpro.zip",
+            "filesize": 308917889,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "55be9e2f",
+                "md5": "d8d54a2a4cb90d556ba28808a77d5371",
+                "sha1": "18b371400f45611c58e94a7c7b7233c084ecc7a7",
+                "sha256": "8684a89d680d3bd3f748497a1c4a2dc13b95562a46e6882e2106abb356377563"
+            }
         }
     ]
 }

--- a/releases/stable/2021-03/51391/release.json
+++ b/releases/stable/2021-03/51391/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "51391",
+    "name": "2021.1.2.51391",
+    "date": "2021-03-11 11:50:28",
+    "track": "stable",
+    "commit": "b831aaad02ec00736c80b0359b54a430a86f4c0c",
+    "detail_url": "https://deskpro.github.io/releases/stable/2021-03/51391/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.2.51391/deskpro.zip",
+    "filesize": 308917889,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "55be9e2f",
+        "md5": "d8d54a2a4cb90d556ba28808a77d5371",
+        "sha1": "18b371400f45611c58e94a7c7b7233c084ecc7a7",
+        "sha256": "8684a89d680d3bd3f748497a1c4a2dc13b95562a46e6882e2106abb356377563"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2021.1.2.51391.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#51391](http://builder.deskprodemo.com/build/51391/)
