### PR TITLE
Release 2021.1.3.51487

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3476,6 +3476,25 @@
                 "sha1": "903648000f2b1050cc2b9a1191e9ca00a94c9386",
                 "sha256": "1def7dffb7fc571eab34b462e1d2041a6e2cbff07b775062f7c6f2fff40a2bba"
             }
+        },
+        {
+            "id": "51487",
+            "name": "2021.1.3.51487",
+            "date": "2021-03-23 15:10:21",
+            "track": "stable",
+            "commit": "530b3fc562576b63d5456623c2933939f7cf84cf",
+            "detail_url": "https://deskpro.github.io/releases/stable/2021-03/51487/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.3.51487/deskpro.zip",
+            "filesize": 308914750,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "259a5862",
+                "md5": "e526a85ba55b44b2aa034bd4a0454f28",
+                "sha1": "bbf002f79c55c6707abc9f62472c0b85666516ad",
+                "sha256": "a9887f45119d3db4b51ab1be7e8f824443c9c15c6321acdb65e240107c8a14c8"
+            }
         }
     ]
 }

--- a/releases/stable/2021-03/51487/release.json
+++ b/releases/stable/2021-03/51487/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "51487",
+    "name": "2021.1.3.51487",
+    "date": "2021-03-23 15:10:21",
+    "track": "stable",
+    "commit": "530b3fc562576b63d5456623c2933939f7cf84cf",
+    "detail_url": "https://deskpro.github.io/releases/stable/2021-03/51487/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.3.51487/deskpro.zip",
+    "filesize": 308914750,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "259a5862",
+        "md5": "e526a85ba55b44b2aa034bd4a0454f28",
+        "sha1": "bbf002f79c55c6707abc9f62472c0b85666516ad",
+        "sha256": "a9887f45119d3db4b51ab1be7e8f824443c9c15c6321acdb65e240107c8a14c8"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2021.1.3.51487.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#51487](http://builder.deskprodemo.com/build/51487/)
