### PR TITLE
Release 2021.1.3.51504

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3495,6 +3495,25 @@
                 "sha1": "bbf002f79c55c6707abc9f62472c0b85666516ad",
                 "sha256": "a9887f45119d3db4b51ab1be7e8f824443c9c15c6321acdb65e240107c8a14c8"
             }
+        },
+        {
+            "id": "51504",
+            "name": "2021.1.3.51504",
+            "date": "2021-03-24 18:18:54",
+            "track": "stable",
+            "commit": "138766aad2a8fda5f338c42179cea208df703626",
+            "detail_url": "https://deskpro.github.io/releases/stable/2021-03/51504/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.3.51504/deskpro.zip",
+            "filesize": 308916013,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "6610ce75",
+                "md5": "33fba3efee49717955ccf3f40bf95114",
+                "sha1": "1a9ea3a2e93e1ca1a1f9e36d19daa0ff4787d8ac",
+                "sha256": "c93708c67c920be42a2607db2154f8b47b45217352b3d174358d9059d9fbb2ed"
+            }
         }
     ]
 }

--- a/releases/stable/2021-03/51504/release.json
+++ b/releases/stable/2021-03/51504/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "51504",
+    "name": "2021.1.3.51504",
+    "date": "2021-03-24 18:18:54",
+    "track": "stable",
+    "commit": "138766aad2a8fda5f338c42179cea208df703626",
+    "detail_url": "https://deskpro.github.io/releases/stable/2021-03/51504/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.3.51504/deskpro.zip",
+    "filesize": 308916013,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "6610ce75",
+        "md5": "33fba3efee49717955ccf3f40bf95114",
+        "sha1": "1a9ea3a2e93e1ca1a1f9e36d19daa0ff4787d8ac",
+        "sha256": "c93708c67c920be42a2607db2154f8b47b45217352b3d174358d9059d9fbb2ed"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2021.1.3.51504.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#51504](http://builder.deskprodemo.com/build/51504/)
