### PR TITLE
Release 2021.1.3.51681

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3514,6 +3514,25 @@
                 "sha1": "1a9ea3a2e93e1ca1a1f9e36d19daa0ff4787d8ac",
                 "sha256": "c93708c67c920be42a2607db2154f8b47b45217352b3d174358d9059d9fbb2ed"
             }
+        },
+        {
+            "id": "51681",
+            "name": "2021.1.3.51681",
+            "date": "2021-04-20 17:04:10",
+            "track": "stable",
+            "commit": "511543cbc8d5bd54e65851bfbb6999d6967e2cae",
+            "detail_url": "https://deskpro.github.io/releases/stable/2021-04/51681/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.3.51681/deskpro.zip",
+            "filesize": 308895765,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "580f5cc5",
+                "md5": "e10c9867eea08cf83e07f6b997232b7e",
+                "sha1": "b34a1856a3e790ee13606d966502aeb5220cfc4c",
+                "sha256": "a46919a154a35fb20c87f51cd0c1d3e1879fec1aa28bac715fbbcb391e7cd2e6"
+            }
         }
     ]
 }

--- a/releases/stable/2021-04/51681/release.json
+++ b/releases/stable/2021-04/51681/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "51681",
+    "name": "2021.1.3.51681",
+    "date": "2021-04-20 17:04:10",
+    "track": "stable",
+    "commit": "511543cbc8d5bd54e65851bfbb6999d6967e2cae",
+    "detail_url": "https://deskpro.github.io/releases/stable/2021-04/51681/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.3.51681/deskpro.zip",
+    "filesize": 308895765,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "580f5cc5",
+        "md5": "e10c9867eea08cf83e07f6b997232b7e",
+        "sha1": "b34a1856a3e790ee13606d966502aeb5220cfc4c",
+        "sha256": "a46919a154a35fb20c87f51cd0c1d3e1879fec1aa28bac715fbbcb391e7cd2e6"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2021.1.3.51681.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#51681](http://builder.deskprodemo.com/build/51681/)
