### PR TITLE
Release 2021.1.4.51684

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3514,6 +3514,25 @@
                 "sha1": "1a9ea3a2e93e1ca1a1f9e36d19daa0ff4787d8ac",
                 "sha256": "c93708c67c920be42a2607db2154f8b47b45217352b3d174358d9059d9fbb2ed"
             }
+        },
+        {
+            "id": "51684",
+            "name": "2021.1.4.51684",
+            "date": "2021-04-21 10:42:47",
+            "track": "stable",
+            "commit": "511543cbc8d5bd54e65851bfbb6999d6967e2cae",
+            "detail_url": "https://deskpro.github.io/releases/stable/2021-04/51684/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.4.51684/deskpro.zip",
+            "filesize": 308896437,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "604ef937",
+                "md5": "9d776f57267d165e9826bb14a64a9337",
+                "sha1": "93e93785fe67cf158a52d34878191773c2d659bd",
+                "sha256": "a53f2b2257fd082ae17380162ebe81b16f30280861d0f0a0222a02f19a77e1b7"
+            }
         }
     ]
 }

--- a/releases/stable/2021-04/51684/release.json
+++ b/releases/stable/2021-04/51684/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "51684",
+    "name": "2021.1.4.51684",
+    "date": "2021-04-21 10:42:47",
+    "track": "stable",
+    "commit": "511543cbc8d5bd54e65851bfbb6999d6967e2cae",
+    "detail_url": "https://deskpro.github.io/releases/stable/2021-04/51684/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.4.51684/deskpro.zip",
+    "filesize": 308896437,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "604ef937",
+        "md5": "9d776f57267d165e9826bb14a64a9337",
+        "sha1": "93e93785fe67cf158a52d34878191773c2d659bd",
+        "sha256": "a53f2b2257fd082ae17380162ebe81b16f30280861d0f0a0222a02f19a77e1b7"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2021.1.4.51684.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#51684](http://builder.deskprodemo.com/build/51684/)
