### PR TITLE
Release 2021.1.7.52233

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3628,6 +3628,25 @@
                 "sha1": "7cd0133559c0f7837cdbe4f9226cccd15a45b938",
                 "sha256": "425faf66d0f594ee7b1b849b8a649f444ba5db417d81bca6a475015be841a372"
             }
+        },
+        {
+            "id": "52233",
+            "name": "2021.1.7.52233",
+            "date": "2021-07-06 17:12:48",
+            "track": "stable",
+            "commit": "b316b4a2227aeecef04a14f920d3821f1920f208",
+            "detail_url": "https://deskpro.github.io/releases/stable/2021-07/52233/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.7.52233/deskpro.zip",
+            "filesize": 314727021,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "a6f36244",
+                "md5": "9189c2b9a4fb7ff3b760b2e4824642fb",
+                "sha1": "553ab9e813e6ccef40a6a63bdeda93743b6d8e7b",
+                "sha256": "fc5215de49e803adcf84636af4dfd52a66e3b51c562ec1c72af01c212bd271ac"
+            }
         }
     ]
 }

--- a/releases/stable/2021-07/52233/release.json
+++ b/releases/stable/2021-07/52233/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "52233",
+    "name": "2021.1.7.52233",
+    "date": "2021-07-06 17:12:48",
+    "track": "stable",
+    "commit": "b316b4a2227aeecef04a14f920d3821f1920f208",
+    "detail_url": "https://deskpro.github.io/releases/stable/2021-07/52233/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.7.52233/deskpro.zip",
+    "filesize": 314727021,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "a6f36244",
+        "md5": "9189c2b9a4fb7ff3b760b2e4824642fb",
+        "sha1": "553ab9e813e6ccef40a6a63bdeda93743b6d8e7b",
+        "sha256": "fc5215de49e803adcf84636af4dfd52a66e3b51c562ec1c72af01c212bd271ac"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2021.1.7.52233.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#52233](http://builder.deskprodemo.com/build/52233/)
