### PR TITLE
Release 2021.1.9.52609

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3666,6 +3666,25 @@
                 "sha1": "d8af4cc15e6503c21e2b1290c5b247855511a122",
                 "sha256": "b9f696f03af74785d9f51bd60729a16a0128c40375bc508da4a05825ecf95fa3"
             }
+        },
+        {
+            "id": "52609",
+            "name": "2021.1.9.52609",
+            "date": "2021-09-15 09:22:52",
+            "track": "stable",
+            "commit": "d8395b17b7805584077a253322192c492d2c9f7c",
+            "detail_url": "https://deskpro.github.io/releases/stable/2021-09/52609/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.9.52609/deskpro.zip",
+            "filesize": 315576095,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "ec9bc18f",
+                "md5": "5b4b01a75ec4a19c556b8b3513957e3c",
+                "sha1": "d418e8d26802f3414b421799f5584f2765e58ad3",
+                "sha256": "9c2e1719b906546a8e6eb6968aab4a238c14fbd6532894fe193f064cfd68a57b"
+            }
         }
     ]
 }

--- a/releases/stable/2021-09/52609/release.json
+++ b/releases/stable/2021-09/52609/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "52609",
+    "name": "2021.1.9.52609",
+    "date": "2021-09-15 09:22:52",
+    "track": "stable",
+    "commit": "d8395b17b7805584077a253322192c492d2c9f7c",
+    "detail_url": "https://deskpro.github.io/releases/stable/2021-09/52609/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2021.1.9.52609/deskpro.zip",
+    "filesize": 315576095,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "ec9bc18f",
+        "md5": "5b4b01a75ec4a19c556b8b3513957e3c",
+        "sha1": "d418e8d26802f3414b421799f5584f2765e58ad3",
+        "sha256": "9c2e1719b906546a8e6eb6968aab4a238c14fbd6532894fe193f064cfd68a57b"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2021.1.9.52609.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#52609](http://builder.deskprodemo.com/build/52609/)
