### PR TITLE
Release 2022.1.1.53229

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3799,6 +3799,25 @@
                 "sha1": "06efc09095a0785cf4758323208bba81103d582c",
                 "sha256": "b7638193fc20f404679f4f0194e78fbdc1ee4441936311c606e7054b7ab8e582"
             }
+        },
+        {
+            "id": "53229",
+            "name": "2022.1.1.53229",
+            "date": "2022-05-13 10:35:50",
+            "track": "stable",
+            "commit": "b0b3cc6d04e9e78840ddc0260bcca097aade1f4a",
+            "detail_url": "https://deskpro.github.io/releases/stable/2022-05/53229/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2022.1.1.53229/deskpro.zip",
+            "filesize": 316350987,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "66292973",
+                "md5": "4eaf73aeb6b9e470dc775816b5932205",
+                "sha1": "b1eec19b0bbb69813c79b99810216f99b11f5128",
+                "sha256": "55d3aff6e57b95a0b877216489a5fab4fe06efc3fe69bc4f1e02e56b55c65096"
+            }
         }
     ]
 }

--- a/releases/stable/2022-05/53229/release.json
+++ b/releases/stable/2022-05/53229/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "53229",
+    "name": "2022.1.1.53229",
+    "date": "2022-05-13 10:35:50",
+    "track": "stable",
+    "commit": "b0b3cc6d04e9e78840ddc0260bcca097aade1f4a",
+    "detail_url": "https://deskpro.github.io/releases/stable/2022-05/53229/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2022.1.1.53229/deskpro.zip",
+    "filesize": 316350987,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "66292973",
+        "md5": "4eaf73aeb6b9e470dc775816b5932205",
+        "sha1": "b1eec19b0bbb69813c79b99810216f99b11f5128",
+        "sha256": "55d3aff6e57b95a0b877216489a5fab4fe06efc3fe69bc4f1e02e56b55c65096"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2022.1.1.53229.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#53229](http://builder.deskprodemo.com/build/53229/)
