### PR TITLE
Release 2022.1.2.53338

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3818,6 +3818,25 @@
                 "sha1": "f720310e1cddedeec6e33e5840d2baecf2e7ad79",
                 "sha256": "25cef83dfdcd9502a4d6369be693b60a07abf312b54d0fcec896f62f871540bd"
             }
+        },
+        {
+            "id": "53338",
+            "name": "2022.1.2.53338",
+            "date": "2022-07-26 10:09:27",
+            "track": "stable",
+            "commit": "e76d95fcc4db193c415db1b6ec56660ec09067a9",
+            "detail_url": "https://deskpro.github.io/releases/stable/2022-07/53338/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2022.1.2.53338/deskpro.zip",
+            "filesize": 316357749,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "7b0977cb",
+                "md5": "d629cf4192ba505a929811f7628ae70f",
+                "sha1": "345e20c2470393c8f9b0605871a5d916745a0dd9",
+                "sha256": "bfb8b0c9aa516b8e67f65bcff54aea6c00cc993cb45984b354841ef4ba0029cc"
+            }
         }
     ]
 }

--- a/releases/stable/2022-07/53338/release.json
+++ b/releases/stable/2022-07/53338/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "53338",
+    "name": "2022.1.2.53338",
+    "date": "2022-07-26 10:09:27",
+    "track": "stable",
+    "commit": "e76d95fcc4db193c415db1b6ec56660ec09067a9",
+    "detail_url": "https://deskpro.github.io/releases/stable/2022-07/53338/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2022.1.2.53338/deskpro.zip",
+    "filesize": 316357749,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "7b0977cb",
+        "md5": "d629cf4192ba505a929811f7628ae70f",
+        "sha1": "345e20c2470393c8f9b0605871a5d916745a0dd9",
+        "sha256": "bfb8b0c9aa516b8e67f65bcff54aea6c00cc993cb45984b354841ef4ba0029cc"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2022.1.2.53338.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#53338](http://builder.deskprodemo.com/build/53338/)
