### PR TITLE
Release 2022.1.2.53371

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3818,6 +3818,25 @@
                 "sha1": "f720310e1cddedeec6e33e5840d2baecf2e7ad79",
                 "sha256": "25cef83dfdcd9502a4d6369be693b60a07abf312b54d0fcec896f62f871540bd"
             }
+        },
+        {
+            "id": "53371",
+            "name": "2022.1.2.53371",
+            "date": "2022-08-16 10:48:31",
+            "track": "stable",
+            "commit": "da476198c4e1392b4d81c8368f716fcbe52df05b",
+            "detail_url": "https://deskpro.github.io/releases/stable/2022-08/53371/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2022.1.2.53371/deskpro.zip",
+            "filesize": 316352736,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "69d97d6",
+                "md5": "ebef8064665a9b74e9dc282cd8fee714",
+                "sha1": "70da3001ad13a60a497be0f5f209f9691469afb4",
+                "sha256": "1cebb174f93f07ed62c8829d1cd2941cf6200416414e623e753ff7d1f97aa925"
+            }
         }
     ]
 }

--- a/releases/stable/2022-08/53371/release.json
+++ b/releases/stable/2022-08/53371/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "53371",
+    "name": "2022.1.2.53371",
+    "date": "2022-08-16 10:48:31",
+    "track": "stable",
+    "commit": "da476198c4e1392b4d81c8368f716fcbe52df05b",
+    "detail_url": "https://deskpro.github.io/releases/stable/2022-08/53371/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2022.1.2.53371/deskpro.zip",
+    "filesize": 316352736,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "69d97d6",
+        "md5": "ebef8064665a9b74e9dc282cd8fee714",
+        "sha1": "70da3001ad13a60a497be0f5f209f9691469afb4",
+        "sha256": "1cebb174f93f07ed62c8829d1cd2941cf6200416414e623e753ff7d1f97aa925"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2022.1.2.53371.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#53371](http://builder.deskprodemo.com/build/53371/)
