### PR TITLE
Release 2022.2.0.53493

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3856,6 +3856,25 @@
                 "sha1": "4c21398ef4c26eaee90104a7b5d12030c022c705",
                 "sha256": "72a9e1929e97d530b8ce75819c7fef764ef138889b0aa7d46bcfb8aa20bc5085"
             }
+        },
+        {
+            "id": "53493",
+            "name": "2022.2.0.53493",
+            "date": "2022-11-15 10:13:46",
+            "track": "stable",
+            "commit": "b1596f64b5e78a3483127419357c11b2fe314983",
+            "detail_url": "https://deskpro.github.io/releases/stable/2022-11/53493/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2022.2.0.53493/deskpro.zip",
+            "filesize": 314709265,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "eba814b2",
+                "md5": "f04342589903e6e4c0e12cf2b5a4cd83",
+                "sha1": "1f720e90b62b8eec615c1d92ba4111e4e2ea9461",
+                "sha256": "a66bc0aeb7fec58c7e339af7d4d35465f666f7c7a4b1d1b4c5a9ada09e67a971"
+            }
         }
     ]
 }

--- a/releases/stable/2022-11/53493/release.json
+++ b/releases/stable/2022-11/53493/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "53493",
+    "name": "2022.2.0.53493",
+    "date": "2022-11-15 10:13:46",
+    "track": "stable",
+    "commit": "b1596f64b5e78a3483127419357c11b2fe314983",
+    "detail_url": "https://deskpro.github.io/releases/stable/2022-11/53493/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2022.2.0.53493/deskpro.zip",
+    "filesize": 314709265,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "eba814b2",
+        "md5": "f04342589903e6e4c0e12cf2b5a4cd83",
+        "sha1": "1f720e90b62b8eec615c1d92ba4111e4e2ea9461",
+        "sha256": "a66bc0aeb7fec58c7e339af7d4d35465f666f7c7a4b1d1b4c5a9ada09e67a971"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2022.2.0.53493.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#53493](http://builder.deskprodemo.com/build/53493/)
