### PR TITLE
Release 2022.2.0.53496

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3856,6 +3856,25 @@
                 "sha1": "4c21398ef4c26eaee90104a7b5d12030c022c705",
                 "sha256": "72a9e1929e97d530b8ce75819c7fef764ef138889b0aa7d46bcfb8aa20bc5085"
             }
+        },
+        {
+            "id": "53496",
+            "name": "2022.2.0.53496",
+            "date": "2022-11-16 19:08:24",
+            "track": "stable",
+            "commit": "904e7d11f8fe4e0c041feeee1a991ae7f72ee353",
+            "detail_url": "https://deskpro.github.io/releases/stable/2022-11/53496/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2022.2.0.53496/deskpro.zip",
+            "filesize": 314709236,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "3e483c4c",
+                "md5": "e1615bfa37712cd892c2467325bd4ed7",
+                "sha1": "ea7f8536e1b8eb57e2cce6f9fc9ac873c42f8276",
+                "sha256": "43643ded990548eae07fa0e1c6afc41a138ddf68936097d9358db5a6fa507043"
+            }
         }
     ]
 }

--- a/releases/stable/2022-11/53496/release.json
+++ b/releases/stable/2022-11/53496/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "53496",
+    "name": "2022.2.0.53496",
+    "date": "2022-11-16 19:08:24",
+    "track": "stable",
+    "commit": "904e7d11f8fe4e0c041feeee1a991ae7f72ee353",
+    "detail_url": "https://deskpro.github.io/releases/stable/2022-11/53496/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2022.2.0.53496/deskpro.zip",
+    "filesize": 314709236,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "3e483c4c",
+        "md5": "e1615bfa37712cd892c2467325bd4ed7",
+        "sha1": "ea7f8536e1b8eb57e2cce6f9fc9ac873c42f8276",
+        "sha256": "43643ded990548eae07fa0e1c6afc41a138ddf68936097d9358db5a6fa507043"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2022.2.0.53496.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#53496](http://builder.deskprodemo.com/build/53496/)
