### PR TITLE
Release 2023.0.53688

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -3932,6 +3932,25 @@
                 "sha1": "9bb4db342567ab10f0d8d87f585e01e378025f03",
                 "sha256": "3ec4b46c822f2fe40a3d680c006c703cc71af32af7a99bf714d615ccf4280190"
             }
+        },
+        {
+            "id": "53688",
+            "name": "2023.0.53688",
+            "date": "2023-04-28 12:17:47",
+            "track": "stable",
+            "commit": "366195b659d84f9fb46056cba150f593aec9ccd3",
+            "detail_url": "https://deskpro.github.io/releases/stable/2023-04/53688/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2023.0.53688/deskpro.zip",
+            "filesize": 316518860,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "b1bf647",
+                "md5": "8a948f5c656ed588725c181c521997fd",
+                "sha1": "b760cb498f836169633751bf59dd20e73f08a762",
+                "sha256": "31860e2481499c445bf48ff71e6eaa575bdadc9861e38d10bf0ac906b74a103f"
+            }
         }
     ]
 }

--- a/releases/stable/2023-04/53688/release.json
+++ b/releases/stable/2023-04/53688/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "53688",
+    "name": "2023.0.53688",
+    "date": "2023-04-28 12:17:47",
+    "track": "stable",
+    "commit": "366195b659d84f9fb46056cba150f593aec9ccd3",
+    "detail_url": "https://deskpro.github.io/releases/stable/2023-04/53688/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2023.0.53688/deskpro.zip",
+    "filesize": 316518860,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "b1bf647",
+        "md5": "8a948f5c656ed588725c181c521997fd",
+        "sha1": "b760cb498f836169633751bf59dd20e73f08a762",
+        "sha256": "31860e2481499c445bf48ff71e6eaa575bdadc9861e38d10bf0ac906b74a103f"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2023.0.53688.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#53688](http://builder.deskprodemo.com/build/53688/)
