### PR TITLE
Release 2023.0.3.53783

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -4027,6 +4027,25 @@
                 "sha1": "65afd7b5b8e80278a076cfc3d7707c9de98dc68c",
                 "sha256": "decd490c1d379fea111fc944b9c79a63d58773477aeeedb77dc78f394cde922d"
             }
+        },
+        {
+            "id": "53783",
+            "name": "2023.0.3.53783",
+            "date": "2023-07-31 10:43:15",
+            "track": "stable",
+            "commit": "5c5c5a2db799d6f82b6f58964b68d242cbeeadd5",
+            "detail_url": "https://deskpro.github.io/releases/stable/2023-07/53783/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2023.0.3.53783/deskpro.zip",
+            "filesize": 316526772,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "8a6890b7",
+                "md5": "718f1c83ec8b2ea2951f5b27f29724d4",
+                "sha1": "7ddf6fe053af6c870e962ecd231296c4119f8304",
+                "sha256": "b1459228be114cd53294daeb38a356de309abae9f42e3997d5dbc563d7d8e5f2"
+            }
         }
     ]
 }

--- a/releases/stable/2023-07/53783/release.json
+++ b/releases/stable/2023-07/53783/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "53783",
+    "name": "2023.0.3.53783",
+    "date": "2023-07-31 10:43:15",
+    "track": "stable",
+    "commit": "5c5c5a2db799d6f82b6f58964b68d242cbeeadd5",
+    "detail_url": "https://deskpro.github.io/releases/stable/2023-07/53783/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2023.0.3.53783/deskpro.zip",
+    "filesize": 316526772,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "8a6890b7",
+        "md5": "718f1c83ec8b2ea2951f5b27f29724d4",
+        "sha1": "7ddf6fe053af6c870e962ecd231296c4119f8304",
+        "sha256": "b1459228be114cd53294daeb38a356de309abae9f42e3997d5dbc563d7d8e5f2"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2023.0.3.53783.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#53783](http://builder.deskprodemo.com/build/53783/)
