### PR TITLE
Release 2023.0.4.53793

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -4046,6 +4046,25 @@
                 "sha1": "7ddf6fe053af6c870e962ecd231296c4119f8304",
                 "sha256": "b1459228be114cd53294daeb38a356de309abae9f42e3997d5dbc563d7d8e5f2"
             }
+        },
+        {
+            "id": "53793",
+            "name": "2023.0.4.53793",
+            "date": "2023-08-07 12:06:00",
+            "track": "stable",
+            "commit": "b39c83ed8dc26408a60acce5da2cbf9e0dcd4714",
+            "detail_url": "https://deskpro.github.io/releases/stable/2023-08/53793/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2023.0.4.53793/deskpro.zip",
+            "filesize": 316526015,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "4ac282d8",
+                "md5": "6b5b168f71093ee9d7d17b6e77d86587",
+                "sha1": "5e002865752f216ca10eedb8ca555ff71dc83d04",
+                "sha256": "1ab4068f0efd374a127620f8d3cb2a713d621aae7a38073cd271e6845578bfd3"
+            }
         }
     ]
 }

--- a/releases/stable/2023-08/53793/release.json
+++ b/releases/stable/2023-08/53793/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "53793",
+    "name": "2023.0.4.53793",
+    "date": "2023-08-07 12:06:00",
+    "track": "stable",
+    "commit": "b39c83ed8dc26408a60acce5da2cbf9e0dcd4714",
+    "detail_url": "https://deskpro.github.io/releases/stable/2023-08/53793/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2023.0.4.53793/deskpro.zip",
+    "filesize": 316526015,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "4ac282d8",
+        "md5": "6b5b168f71093ee9d7d17b6e77d86587",
+        "sha1": "5e002865752f216ca10eedb8ca555ff71dc83d04",
+        "sha256": "1ab4068f0efd374a127620f8d3cb2a713d621aae7a38073cd271e6845578bfd3"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2023.0.4.53793.

Branch: [master](https://github.com/DeskPRO/DeskPRO/tree/master)
Build details: [#53793](http://builder.deskprodemo.com/build/53793/)
