### PR TITLE
Release 2024.0.0.53942

### DIFF
--- a/releases/manifest.json
+++ b/releases/manifest.json
@@ -4065,6 +4065,25 @@
                 "sha1": "5e002865752f216ca10eedb8ca555ff71dc83d04",
                 "sha256": "1ab4068f0efd374a127620f8d3cb2a713d621aae7a38073cd271e6845578bfd3"
             }
+        },
+        {
+            "id": "53942",
+            "name": "2024.0.0.53942",
+            "date": "2024-01-19 16:28:30",
+            "track": "stable",
+            "commit": "cf80a6256f43d2a3cba1283dca47c334bac18c19",
+            "detail_url": "https://deskpro.github.io/releases/stable/2024-01/53942/release.json",
+            "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2024.0.0.53942/deskpro.zip",
+            "filesize": 316538465,
+            "flags": [
+                "auto_enabled"
+            ],
+            "checksums": {
+                "crc32": "f9d6fd16",
+                "md5": "9838a9efa520533234ed7a77e8e73a95",
+                "sha1": "3e1a005816f4b82c539bb7589da1cf08961919de",
+                "sha256": "f436da00dd0ad5afd727ea2fd8930552a9a3cae2d836194b1eff376be6832339"
+            }
         }
     ]
 }

--- a/releases/stable/2024-01/53942/release.json
+++ b/releases/stable/2024-01/53942/release.json
@@ -1,0 +1,19 @@
+{
+    "id": "53942",
+    "name": "2024.0.0.53942",
+    "date": "2024-01-19 16:28:30",
+    "track": "stable",
+    "commit": "cf80a6256f43d2a3cba1283dca47c334bac18c19",
+    "detail_url": "https://deskpro.github.io/releases/stable/2024-01/53942/release.json",
+    "zip_url": "https://github.com/DeskPRO/deskpro.github.io/releases/download/2024.0.0.53942/deskpro.zip",
+    "filesize": 316538465,
+    "flags": [
+        "auto_enabled"
+    ],
+    "checksums": {
+        "crc32": "f9d6fd16",
+        "md5": "9838a9efa520533234ed7a77e8e73a95",
+        "sha1": "3e1a005816f4b82c539bb7589da1cf08961919de",
+        "sha256": "f436da00dd0ad5afd727ea2fd8930552a9a3cae2d836194b1eff376be6832339"
+    }
+}


### PR DESCRIPTION

This pull request releases DeskPRO 2024.0.0.53942.

Branch: [cn/blobs-ext-auth2](https://github.com/DeskPRO/DeskPRO/tree/cn/blobs-ext-auth2)
Build details: [#53942](http://builder.deskprodemo.com/build/53942/)
